### PR TITLE
Recursive not found fix for trailing slash routes

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -298,8 +298,12 @@ func (mx *Mux) Mount(pattern string, handler http.Handler) {
 	})
 
 	if pattern == "" || pattern[len(pattern)-1] != '/' {
+		notFoundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mx.NotFoundHandler().ServeHTTP(w, r)
+		})
+
 		mx.handle(mALL|mSTUB, pattern, subHandler)
-		mx.handle(mALL|mSTUB, pattern+"/", mx.NotFoundHandler())
+		mx.handle(mALL|mSTUB, pattern+"/", notFoundHandler)
 		pattern += "/"
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -484,6 +484,19 @@ func TestMuxComplicatedNotFound(t *testing.T) {
 	if _, body := testRequest(t, ts, "GET", "/private/resource/nope", nil); body != "custom not-found" {
 		t.Fatalf(body)
 	}
+	// check custom not-found on trailing slash routes
+	if _, body := testRequest(t, ts, "GET", "/auth/", nil); body != "custom not-found" {
+		t.Fatalf(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/public/", nil); body != "custom not-found" {
+		t.Fatalf(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/private/", nil); body != "custom not-found" {
+		t.Fatalf(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/private/resource/", nil); body != "custom not-found" {
+		t.Fatalf(body)
+	}
 }
 
 func TestMuxWith(t *testing.T) {


### PR DESCRIPTION
There was an issue using custom not found handlers in auto-generated trailing slash routes. The tests show the expected behavior for recursive mounts.

The not found handler is wrapped in a inline handler for run-time evaluation of the mux not found routine.