### PR TITLE
Unbreaking the 'FileServer' example

### DIFF
--- a/_examples/fileserver/main.go
+++ b/_examples/fileserver/main.go
@@ -26,7 +26,7 @@ func main() {
 // FileServer conveniently sets up a http.FileServer handler to serve
 // static files from a http.FileSystem.
 func FileServer(r chi.Router, path string, root http.FileSystem) {
-	if strings.ContainsAny(path, "{}*") {
+	if strings.ContainsAny(path, "*") {
 		panic("FileServer does not permit URL parameters.")
 	}
 


### PR DESCRIPTION
Not sure what this is supposed to be, but after moving from Chi 2.1 => 3.1, I had problems with the FileServer.

The old one (https://github.com/go-chi/chi/blob/e6033ea75479391a4bce3918fc119cad31e1cb30/mux.go#L305) was matching

```
":*"
```

The new example is matching this, but this is giving me problems:

```
"{}*"
```

Just trying out different thing, in my project at least this works:

```
"*"
```