### PR TITLE
Update basicWriter.bytes with ReadFrom result

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -115,7 +115,9 @@ func (f *httpFancyWriter) ReadFrom(r io.Reader) (int64, error) {
 	}
 	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)
 	f.basicWriter.maybeWriteHeader()
-	return rf.ReadFrom(r)
+	n, err := rf.ReadFrom(r)
+	f.basicWriter.bytes += int(n)
+	return n, err
 }
 
 var _ http.CloseNotifier = &httpFancyWriter{}


### PR DESCRIPTION
This ensures that the wrapped response writer middleware properly tracks the number of bytes written in the response body, even when operations make use of the writer's `ReadFrom` method.