### PR TITLE
Introduce chi.Config for very minor config options of the Mux

### DIFF
--- a/chi.go
+++ b/chi.go
@@ -32,8 +32,8 @@ package chi
 import "net/http"
 
 // NewRouter returns a new Mux object that implements the Router interface.
-func NewRouter() *Mux {
-	return NewMux()
+func NewRouter(config ...Config) *Mux {
+	return NewMux(config...)
 }
 
 // Router consisting of the core routing methods used by chi's Mux,

--- a/mux_test.go
+++ b/mux_test.go
@@ -716,7 +716,10 @@ func TestMuxRouteGroups(t *testing.T) {
 }
 
 func TestMuxHeadGet(t *testing.T) {
-	r := NewRouter()
+	r := NewRouter(Config{
+		AutoHeadGet: true,
+	})
+
 	r.Get("/hi", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Test", "yes")
 		w.Write([]byte("bye"))


### PR DESCRIPTION
And yet.. another alternative for how to solve https://github.com/go-chi/chi/issues/238 

This introduces `chi.Config` which offers `AutoHeadGet bool` to vary the routing execution. The `chi.Config` can be passed as an optional argument to `chi.NewRouter()`.

I like the simplicity of this solution, which also has no executional overhead versus PR #248, but I'm wary to open a can of worms for having more nuances to support via a Config. 