### PR TITLE
Add generic middleware logger interface

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -74,9 +74,14 @@ func WithLogEntry(r *http.Request, entry LogEntry) *http.Request {
 	return r
 }
 
+// LoggerInterface accepts printing to stdlib logger or compatible logger.
+type LoggerInterface interface {
+	Print(v ...interface{})
+}
+
 // DefaultLogFormatter is a simple logger that implements a LogFormatter.
 type DefaultLogFormatter struct {
-	Logger *log.Logger
+	Logger LoggerInterface
 }
 
 // NewLogEntry creates a new LogEntry for the request.


### PR DESCRIPTION
As I prefer to use a custom logger making the logger an interface means I can inject my own for request logging.

This also has the property of being fully backwards compatible with the stdlib logger.