### PR TITLE
Fix: regex matching only part of parameter

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -676,6 +676,15 @@ func patNextSegment(pattern string) (nodeTyp, string, string, byte, int, int) {
 			key = key[:idx]
 		}
 
+		if len(rexpat) > 0 {
+			if rexpat[0] != '^' {
+				rexpat = "^" + rexpat
+			}
+			if rexpat[len(rexpat)-1] != '$' {
+				rexpat = rexpat + "$"
+			}
+		}
+
 		return nt, key, rexpat, tail, ps, pe
 	}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -333,6 +333,31 @@ func TestTreeRegexp(t *testing.T) {
 	}
 }
 
+func TestTreeRegexMatchWholeParam(t *testing.T) {
+	hStub1 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	rctx := NewRouteContext()
+	tr := &node{}
+	tr.InsertRoute(mGET, "/{id:[0-9]+}", hStub1)
+
+	tests := []struct {
+		url             string
+		expectedHandler http.Handler
+	}{
+		{url: "/13", expectedHandler: hStub1},
+		{url: "/a13", expectedHandler: nil},
+		{url: "/13.jpg", expectedHandler: nil},
+		{url: "/a13.jpg", expectedHandler: nil},
+	}
+
+	for _, tc := range tests {
+		_, _, handler := tr.FindRoute(rctx, mGET, tc.url)
+		if fmt.Sprintf("%v", tc.expectedHandler) != fmt.Sprintf("%v", handler) {
+			t.Errorf("expecting handler:%v , got:%v", tc.expectedHandler, handler)
+		}
+	}
+}
+
 func TestTreeFindPattern(t *testing.T) {
 	hStub1 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	hStub2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})


### PR DESCRIPTION
I'm not sure if this is the best solution to the problem, but I think it works.
Here is my problem:
I have route defined:
```golang
router.Route("/{ID:[0-9]+}", func (r chi.Router) {
```
I expect to only match on numeric ids, but something like `a1.jpg` also matches.