### PR TITLE
Add appengine as a build target for Go 1.8.* targets.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-present Peter Kieltyka (https://github.com/pkieltyka)
+Copyright (c) 2015-present Peter Kieltyka (https://github.com/pkieltyka), Google Inc.
 
 MIT License
 

--- a/middleware/closenotify18.go
+++ b/middleware/closenotify18.go
@@ -1,4 +1,4 @@
-// +build go1.8
+// +build go1.8 appengine
 
 package middleware
 

--- a/middleware/compress18.go
+++ b/middleware/compress18.go
@@ -1,4 +1,4 @@
-// +build go1.8
+// +build go1.8 appengine
 
 package middleware
 

--- a/middleware/wrap_writer18.go
+++ b/middleware/wrap_writer18.go
@@ -1,4 +1,4 @@
-// +build go1.8
+// +build go1.8 appengine
 
 package middleware
 


### PR DESCRIPTION
Please note the addition of Google, Inc. in the LICENSE file is required of me if offering patches to an open source project.

Fixes #267.