### PR TITLE
New chi.RegisterMethod(method) to add support for custom HTTP methods

### DIFF
--- a/_examples/custom-method/main.go
+++ b/_examples/custom-method/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+)
+
+func init() {
+	chi.RegisterMethod("LINK")
+	chi.RegisterMethod("UNLINK")
+	chi.RegisterMethod("WOOHOO")
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.Logger)
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello world"))
+	})
+	r.MethodFunc("LINK", "/link", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("custom link method"))
+	})
+	r.MethodFunc("WOOHOO", "/woo", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("custom woohoo method"))
+	})
+	r.HandleFunc("/everything", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("capturing all standard http methods, as well as LINK, UNLINK and WOOHOO"))
+	})
+	http.ListenAndServe(":3333", r)
+}

--- a/tree.go
+++ b/tree.go
@@ -6,44 +6,59 @@ package chi
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
 type methodTyp int
 
 const (
-	mCONNECT methodTyp = 1 << iota
+	mSTUB methodTyp = 1 << iota
+	mCONNECT
 	mDELETE
 	mGET
 	mHEAD
-	mLINK
 	mOPTIONS
 	mPATCH
 	mPOST
 	mPUT
 	mTRACE
-	mUNLINK
-	mSTUB
-
-	mALL methodTyp = mCONNECT | mDELETE | mGET | mHEAD | mLINK |
-		mOPTIONS | mPATCH | mPOST | mPUT | mTRACE | mUNLINK
 )
+
+var mALL methodTyp = mCONNECT | mDELETE | mGET | mHEAD |
+	mOPTIONS | mPATCH | mPOST | mPUT | mTRACE
 
 var methodMap = map[string]methodTyp{
 	"CONNECT": mCONNECT,
 	"DELETE":  mDELETE,
 	"GET":     mGET,
 	"HEAD":    mHEAD,
-	"LINK":    mLINK,
 	"OPTIONS": mOPTIONS,
 	"PATCH":   mPATCH,
 	"POST":    mPOST,
 	"PUT":     mPUT,
 	"TRACE":   mTRACE,
-	"UNLINK":  mUNLINK,
+}
+
+func RegisterMethod(method string) {
+	if method == "" {
+		return
+	}
+	method = strings.ToUpper(method)
+	if _, ok := methodMap[method]; ok {
+		return
+	}
+	n := len(methodMap)
+	if n > strconv.IntSize {
+		panic(fmt.Sprintf("chi: max number of methods reached (%d)", strconv.IntSize))
+	}
+	mt := methodTyp(math.Exp2(float64(n)))
+	methodMap[method] = mt
+	mALL |= mt
 }
 
 type nodeTyp uint8


### PR DESCRIPTION
Fixes https://github.com/go-chi/chi/issues/264 by allowing users to add support for methods. Check out _examples/custom-method

In addition, this PR removes native support for LINK and UNLINK http methods as they are extended methods. Please use chi.RegisterMethod("LINK") and chi.RegisterMethod("UNLINK") in an init function instead.