### PR TITLE
Fixed 'elasped' misspelling of 'elapsed'

### DIFF
--- a/_examples/logging/main.go
+++ b/_examples/logging/main.go
@@ -103,7 +103,7 @@ type StructuredLoggerEntry struct {
 func (l *StructuredLoggerEntry) Write(status, bytes int, elapsed time.Duration) {
 	l.Logger = l.Logger.WithFields(logrus.Fields{
 		"resp_status": status, "resp_bytes_length": bytes,
-		"resp_elasped_ms": float64(elapsed.Nanoseconds()) / 1000000.0,
+		"resp_elapsed_ms": float64(elapsed.Nanoseconds()) / 1000000.0,
 	})
 
 	l.Logger.Infoln("request complete")


### PR DESCRIPTION
Fixed misspelling of logging example.