### PR TITLE
Fixed a panic when using the `Router` returned from `*Mux.With(...)` as an http.Handler

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -233,7 +233,12 @@ func (mx *Mux) With(middlewares ...func(http.Handler) http.Handler) Router {
 	}
 	mws = append(mws, middlewares...)
 
-	im := &Mux{inline: true, parent: mx, tree: mx.tree, middlewares: mws}
+	im := NewMux()
+	im.inline = true
+	im.parent = mx
+	im.tree = mx.tree
+	im.middlewares = mws
+
 	return im
 }
 

--- a/mux.go
+++ b/mux.go
@@ -35,7 +35,7 @@ type Mux struct {
 	handler http.Handler
 
 	// Routing context pool
-	pool sync.Pool
+	pool *sync.Pool
 
 	// Custom route not found handler
 	notFoundHandler http.HandlerFunc
@@ -47,7 +47,7 @@ type Mux struct {
 // NewMux returns a newly initialized Mux object that implements the Router
 // interface.
 func NewMux() *Mux {
-	mux := &Mux{tree: &node{}}
+	mux := &Mux{tree: &node{}, pool: new(sync.Pool)}
 	mux.pool.New = func() interface{} {
 		return NewRouteContext()
 	}
@@ -233,11 +233,7 @@ func (mx *Mux) With(middlewares ...func(http.Handler) http.Handler) Router {
 	}
 	mws = append(mws, middlewares...)
 
-	im := NewMux()
-	im.inline = true
-	im.parent = mx
-	im.tree = mx.tree
-	im.middlewares = mws
+	im := &Mux{pool: mx.pool, inline: true, parent: mx, tree: mx.tree, middlewares: mws}
 
 	return im
 }

--- a/mux.go
+++ b/mux.go
@@ -47,7 +47,7 @@ type Mux struct {
 // NewMux returns a newly initialized Mux object that implements the Router
 // interface.
 func NewMux() *Mux {
-	mux := &Mux{tree: &node{}, pool: new(sync.Pool)}
+	mux := &Mux{tree: &node{}, pool: &sync.Pool{}}
 	mux.pool.New = func() interface{} {
 		return NewRouteContext()
 	}

--- a/mux_test.go
+++ b/mux_test.go
@@ -583,6 +583,26 @@ func TestMuxWith(t *testing.T) {
 	}
 }
 
+func TestRouterFromMuxWith(t *testing.T) {
+	t.Parallel()
+
+	r := NewRouter()
+
+	with := r.With(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	})
+
+	with.Get("/with_middleware", func(w http.ResponseWriter, r *http.Request) {})
+
+	ts := httptest.NewServer(with)
+	defer ts.Close()
+
+	// Without the fix this test was committed with, this causes a panic.
+	testRequest(t, ts, http.MethodGet, "/with_middleware", nil)
+}
+
 func TestMuxMiddlewareStack(t *testing.T) {
 	var stdmwInit, stdmwHandler uint64
 	stdmw := func(next http.Handler) http.Handler {


### PR DESCRIPTION
This panic was a result of the `*Mux` returned from `*Mux.With(...)` not having it's `*Mux.pool.New` function set. The returned `*Mux` is now properly initialized.

Added a test to catch this. Here's what the failure looked like before the fix:

```
> go test -run TestRouterFromMuxWith
2017/10/26 16:48:21 http: panic serving 127.0.0.1:56700: interface conversion: interface {} is nil, not *chi.Context
goroutine 34 [running]:
net/http.(*conn).serve.func1(0xc420150000)
	/usr/local/Cellar/go/1.9.1/libexec/src/net/http/server.go:1697 +0xd0
panic(0x12df700, 0xc420088900)
	/usr/local/Cellar/go/1.9.1/libexec/src/runtime/panic.go:491 +0x283
github.com/go-chi/chi.(*Mux).ServeHTTP(0xc420110230, 0x14b04e0, 0xc420174000, 0xc420166000)
	$GOPATH/go/src/github.com/go-chi/chi/mux.go:77 +0x36c
net/http.serverHandler.ServeHTTP(0xc420084ea0, 0x14b04e0, 0xc420174000, 0xc420166000)
	/usr/local/Cellar/go/1.9.1/libexec/src/net/http/server.go:2619 +0xb4
net/http.(*conn).serve(0xc420150000, 0x14b0aa0, 0xc420128140)
	/usr/local/Cellar/go/1.9.1/libexec/src/net/http/server.go:1801 +0x71d
created by net/http.(*Server).Serve
	/usr/local/Cellar/go/1.9.1/libexec/src/net/http/server.go:2720 +0x288
--- FAIL: TestRouterFromMuxWith (0.00s)
	mux_test.go:1527: Get http://127.0.0.1:56699/with_middleware: EOF
FAIL
exit status 1
FAIL	github.com/go-chi/chi	0.021s
```