### PR TITLE
Fix missing profile subpages

### DIFF
--- a/middleware/profiler.go
+++ b/middleware/profiler.go
@@ -29,15 +29,11 @@ func Profiler() http.Handler {
 		http.Redirect(w, r, r.RequestURI+"/", 301)
 	})
 
-	r.HandleFunc("/pprof/", pprof.Index)
+	r.HandleFunc("/pprof/*", pprof.Index)
 	r.HandleFunc("/pprof/cmdline", pprof.Cmdline)
 	r.HandleFunc("/pprof/profile", pprof.Profile)
 	r.HandleFunc("/pprof/symbol", pprof.Symbol)
 	r.HandleFunc("/pprof/trace", pprof.Trace)
-	r.Handle("/pprof/block", pprof.Handler("block"))
-	r.Handle("/pprof/heap", pprof.Handler("heap"))
-	r.Handle("/pprof/goroutine", pprof.Handler("goroutine"))
-	r.Handle("/pprof/threadcreate", pprof.Handler("threadcreate"))
 	r.HandleFunc("/vars", expVars)
 
 	return r


### PR DESCRIPTION
Let pprof.Index handle routing for the different profiles,
just like it does with net/http's router.

Fixes  #278