### PR TITLE
Route trailing slash on mounted sub-routers

### DIFF
--- a/middleware/strip_test.go
+++ b/middleware/strip_test.go
@@ -65,6 +65,9 @@ func TestStripSlashesInRoute(t *testing.T) {
 
 	r.Route("/accounts/{accountID}", func(r chi.Router) {
 		r.Use(StripSlashes)
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("accounts index"))
+		})
 		r.Get("/query", func(w http.ResponseWriter, r *http.Request) {
 			accountID := chi.URLParam(r, "accountID")
 			w.Write([]byte(accountID))
@@ -78,6 +81,12 @@ func TestStripSlashesInRoute(t *testing.T) {
 		t.Fatalf(resp)
 	}
 	if _, resp := testRequest(t, ts, "GET", "/hi/", nil); resp != "nothing here" {
+		t.Fatalf(resp)
+	}
+	if _, resp := testRequest(t, ts, "GET", "/accounts/admin", nil); resp != "accounts index" {
+		t.Fatalf(resp)
+	}
+	if _, resp := testRequest(t, ts, "GET", "/accounts/admin/", nil); resp != "accounts index" {
 		t.Fatalf(resp)
 	}
 	if _, resp := testRequest(t, ts, "GET", "/accounts/admin/query", nil); resp != "admin" {

--- a/mux.go
+++ b/mux.go
@@ -292,12 +292,8 @@ func (mx *Mux) Mount(pattern string, handler http.Handler) {
 	})
 
 	if pattern == "" || pattern[len(pattern)-1] != '/' {
-		notFoundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			mx.NotFoundHandler().ServeHTTP(w, r)
-		})
-
 		mx.handle(mALL|mSTUB, pattern, mountHandler)
-		mx.handle(mALL|mSTUB, pattern+"/", notFoundHandler)
+		mx.handle(mALL|mSTUB, pattern+"/", mountHandler)
 		pattern += "/"
 	}
 


### PR DESCRIPTION
This PR addresses issue #260 

I'm not convinced yet this is the correct behaviour, but it is convenient.

Waiting to hear feedback from the community before we merge it.