### PR TITLE
Add new default type image/svg+xml

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -29,7 +29,7 @@ var defaultContentTypes = map[string]struct{}{
 	"application/json":         struct{}{},
 	"application/atom+xml":     struct{}{},
 	"application/rss+xml":      struct{}{},
-        "image/svg+xml":            struct{}{},
+	"image/svg+xml":            struct{}{},
 }
 
 // DefaultCompress is a middleware that compresses response

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -29,6 +29,7 @@ var defaultContentTypes = map[string]struct{}{
 	"application/json":         struct{}{},
 	"application/atom+xml":     struct{}{},
 	"application/rss+xml":      struct{}{},
+        "image/svg+xml":            struct{}{},
 }
 
 // DefaultCompress is a middleware that compresses response


### PR DESCRIPTION
`image/svg+xml` should be considered as a default type especially because it can be nicely compressed.