### PR TITLE
Expose a property to disable color logging

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -16,7 +16,7 @@ var (
 	// DefaultLogger is called by the Logger middleware handler to log each request.
 	// Its made a package-level variable so that it can be reconfigured for custom
 	// logging configurations.
-	DefaultLogger = RequestLogger(&DefaultLogFormatter{Logger: log.New(os.Stdout, "", log.LstdFlags)})
+	DefaultLogger = RequestLogger(&DefaultLogFormatter{Logger: log.New(os.Stdout, "", log.LstdFlags), NoColor: false})
 )
 
 // Logger is a middleware that logs the start and end of each request, along
@@ -81,29 +81,32 @@ type LoggerInterface interface {
 
 // DefaultLogFormatter is a simple logger that implements a LogFormatter.
 type DefaultLogFormatter struct {
-	Logger LoggerInterface
+	Logger  LoggerInterface
+	NoColor bool
 }
 
 // NewLogEntry creates a new LogEntry for the request.
 func (l *DefaultLogFormatter) NewLogEntry(r *http.Request) LogEntry {
+	useColor := !l.NoColor
 	entry := &defaultLogEntry{
 		DefaultLogFormatter: l,
 		request:             r,
 		buf:                 &bytes.Buffer{},
+		useColor:            useColor,
 	}
 
 	reqID := GetReqID(r.Context())
 	if reqID != "" {
-		cW(entry.buf, nYellow, "[%s] ", reqID)
+		cW(entry.buf, useColor, nYellow, "[%s] ", reqID)
 	}
-	cW(entry.buf, nCyan, "\"")
-	cW(entry.buf, bMagenta, "%s ", r.Method)
+	cW(entry.buf, useColor, nCyan, "\"")
+	cW(entry.buf, useColor, bMagenta, "%s ", r.Method)
 
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
 	}
-	cW(entry.buf, nCyan, "%s://%s%s %s\" ", scheme, r.Host, r.RequestURI, r.Proto)
+	cW(entry.buf, useColor, nCyan, "%s://%s%s %s\" ", scheme, r.Host, r.RequestURI, r.Proto)
 
 	entry.buf.WriteString("from ")
 	entry.buf.WriteString(r.RemoteAddr)
@@ -114,33 +117,34 @@ func (l *DefaultLogFormatter) NewLogEntry(r *http.Request) LogEntry {
 
 type defaultLogEntry struct {
 	*DefaultLogFormatter
-	request *http.Request
-	buf     *bytes.Buffer
+	request  *http.Request
+	buf      *bytes.Buffer
+	useColor bool
 }
 
 func (l *defaultLogEntry) Write(status, bytes int, elapsed time.Duration) {
 	switch {
 	case status < 200:
-		cW(l.buf, bBlue, "%03d", status)
+		cW(l.buf, l.useColor, bBlue, "%03d", status)
 	case status < 300:
-		cW(l.buf, bGreen, "%03d", status)
+		cW(l.buf, l.useColor, bGreen, "%03d", status)
 	case status < 400:
-		cW(l.buf, bCyan, "%03d", status)
+		cW(l.buf, l.useColor, bCyan, "%03d", status)
 	case status < 500:
-		cW(l.buf, bYellow, "%03d", status)
+		cW(l.buf, l.useColor, bYellow, "%03d", status)
 	default:
-		cW(l.buf, bRed, "%03d", status)
+		cW(l.buf, l.useColor, bRed, "%03d", status)
 	}
 
-	cW(l.buf, bBlue, " %dB", bytes)
+	cW(l.buf, l.useColor, bBlue, " %dB", bytes)
 
 	l.buf.WriteString(" in ")
 	if elapsed < 500*time.Millisecond {
-		cW(l.buf, nGreen, "%s", elapsed)
+		cW(l.buf, l.useColor, nGreen, "%s", elapsed)
 	} else if elapsed < 5*time.Second {
-		cW(l.buf, nYellow, "%s", elapsed)
+		cW(l.buf, l.useColor, nYellow, "%s", elapsed)
 	} else {
-		cW(l.buf, nRed, "%s", elapsed)
+		cW(l.buf, l.useColor, nRed, "%s", elapsed)
 	}
 
 	l.Logger.Print(l.buf.String())
@@ -148,7 +152,7 @@ func (l *defaultLogEntry) Write(status, bytes int, elapsed time.Duration) {
 
 func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
 	panicEntry := l.NewLogEntry(l.request).(*defaultLogEntry)
-	cW(panicEntry.buf, bRed, "panic: %+v", v)
+	cW(panicEntry.buf, l.useColor, bRed, "panic: %+v", v)
 	l.Logger.Print(panicEntry.buf.String())
 	l.Logger.Print(string(stack))
 }

--- a/middleware/terminal.go
+++ b/middleware/terminal.go
@@ -52,12 +52,12 @@ func init() {
 }
 
 // colorWrite
-func cW(w io.Writer, color []byte, s string, args ...interface{}) {
-	if isTTY {
+func cW(w io.Writer, useColor bool, color []byte, s string, args ...interface{}) {
+	if isTTY && useColor {
 		w.Write(color)
 	}
 	fmt.Fprintf(w, s, args...)
-	if isTTY {
+	if isTTY && useColor {
 		w.Write(reset)
 	}
 }


### PR DESCRIPTION
The TTY check assumes we are logging to stdout, however, since the logger can be changed (e.g. to a file) this check is insufficient.

To work around this issue, we expose NoColor on the DefaultLogFormatter in a backwards-compatible manner.

Fixes #290.

Ideally this could in the future be refactored and expose e.g. `Logger` / `ColorLogger`, giving more control to the user and perhaps avoiding the TTY check altogether.