### PR TITLE
bug fix: wroteHeader should be set when Flush is done

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -83,6 +83,8 @@ type flushWriter struct {
 }
 
 func (f *flushWriter) Flush() {
+	f.wroteHeader = true
+
 	fl := f.basicWriter.ResponseWriter.(http.Flusher)
 	fl.Flush()
 }
@@ -102,6 +104,8 @@ func (f *httpFancyWriter) CloseNotify() <-chan bool {
 	return cn.CloseNotify()
 }
 func (f *httpFancyWriter) Flush() {
+	f.wroteHeader = true
+
 	fl := f.basicWriter.ResponseWriter.(http.Flusher)
 	fl.Flush()
 }
@@ -140,6 +144,8 @@ func (f *http2FancyWriter) CloseNotify() <-chan bool {
 	return cn.CloseNotify()
 }
 func (f *http2FancyWriter) Flush() {
+	f.wroteHeader = true
+
 	fl := f.basicWriter.ResponseWriter.(http.Flusher)
 	fl.Flush()
 }

--- a/middleware/wrap_writer_test.go
+++ b/middleware/wrap_writer_test.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFlushWriterRemembersWroteHeaderWhenFlushed(t *testing.T) {
+	f := &flushWriter{basicWriter{ResponseWriter: httptest.NewRecorder()}}
+	f.Flush()
+
+	if !f.wroteHeader {
+		t.Fatal("want Flush to have set wroteHeader=true")
+	}
+}
+
+func TestHttpFancyWriterRemembersWroteHeaderWhenFlushed(t *testing.T) {
+	f := &httpFancyWriter{basicWriter{ResponseWriter: httptest.NewRecorder()}}
+	f.Flush()
+
+	if !f.wroteHeader {
+		t.Fatal("want Flush to have set wroteHeader=true")
+	}
+}
+
+func TestHttp2FancyWriterRemembersWroteHeaderWhenFlushed(t *testing.T) {
+	f := &http2FancyWriter{basicWriter{ResponseWriter: httptest.NewRecorder()}}
+	f.Flush()
+
+	if !f.wroteHeader {
+		t.Fatal("want Flush to have set wroteHeader=true")
+	}
+}


### PR DESCRIPTION
WrapResponseWriter currently does `WriteHeader` when `Write` is called and assumed the operation is idempotent.

This introduces warnings if you call `Flush` first and then `Write` specifically of the form:

```
http: multiple response.WriteHeader calls
```

The go stdlib `response.Flush` implementation does a `wroteHeader=true` assignment when Flush is done, and then writes a 200. This change aligns with the behavior of the stdlib Flush / Write /  WriteHeader dance.

To see this in action, I've written this simple gist: https://gist.github.com/cyx/1e5abe141ee77e4c5b2087133360b0ea