### PR TITLE
Add go.mod with v3 as module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/go-chi/chi/v3


### PR DESCRIPTION
The latest version of go toolchain has added support[1] for versioned
modules. This change adds a go.mod file with v3 as the version, to
enable use with vgo and the proposed go module system in the future.

[1]: https://go-review.googlesource.com/c/go/+/114500