### PR TITLE
Add support for Brotli compression

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -8,19 +8,79 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"regexp"
+	"sort"
 	"strings"
-
-	brotli_enc "gopkg.in/kothar/brotli-go.v0/enc"
 )
 
-type encoding int
+var encoders = map[string]EncoderFunc{}
 
-const (
-	encodingNone encoding = iota
-	encodingGzip
-	encodingDeflate
-	encodingBrotli
-)
+var acceptEncodingAlgorithmsRe = regexp.MustCompile(`([a-z]{2,}|\*)`)
+
+func init() {
+	// TODO:
+	// lzma: Opera.
+	// sdch: Chrome, Android. Gzip output + dictionary header.
+	// br:   Brotli.
+
+	// TODO: Exception for old MSIE browsers that can't handle non-HTML?
+	// https://zoompf.com/blog/2012/02/lose-the-wait-http-compression
+	SetEncoder("gzip", encoderGzip)
+
+	// HTTP 1.1 "deflate" (RFC 2616) stands for DEFLATE data (RFC 1951)
+	// wrapped with zlib (RFC 1950). The zlib wrapper uses Adler-32
+	// checksum compared to CRC-32 used in "gzip" and thus is faster.
+	//
+	// But.. some old browsers (MSIE, Safari 5.1) incorrectly expect
+	// raw DEFLATE data only, without the mentioned zlib wrapper.
+	// Because of this major confusion, most modern browsers try it
+	// both ways, first looking for zlib headers.
+	// Quote by Mark Adler: http://stackoverflow.com/a/9186091/385548
+	//
+	// The list of browsers having problems is quite big, see:
+	// http://zoompf.com/blog/2012/02/lose-the-wait-http-compression
+	// https://web.archive.org/web/20120321182910/http://www.vervestudios.co/projects/compression-tests/results
+	//
+	// That's why we prefer gzip over deflate. It's just more reliable
+	// and not significantly slower than gzip.
+	SetEncoder("deflate", encoderDeflate)
+
+	// NOTE: Not implemented, intentionally:
+	// case "compress": // LZW. Deprecated.
+	// case "bzip2":    // Too slow on-the-fly.
+	// case "zopfli":   // Too slow on-the-fly.
+	// case "xz":       // Too slow on-the-fly.
+}
+
+// An EncoderFunc is a function that wraps the provided ResponseWriter with a
+// streaming compression algorithm and returns it.
+//
+// In case of failure, the function should return nil.
+type EncoderFunc func(w http.ResponseWriter, level int) io.Writer
+
+// SetEncoder can be used to set the implementation of a compression algorithm.
+//
+// The encoding should be a standardised identifier. See:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
+//
+// For example, add the Brotli algortithm:
+//
+//  import brotli_enc "gopkg.in/kothar/brotli-go.v0/enc"
+//
+//  middleware.SetEncoder("br", func(w http.ResponseWriter, level int) io.Writer {
+//    params := brotli_enc.NewBrotliParams()
+//    params.SetQuality(level)
+//    return brotli_enc.NewBrotliWriter(params, w)
+//  })
+func SetEncoder(encoding string, fn EncoderFunc) {
+	if encoding == "" {
+		panic("the encoding can not be empty")
+	}
+	if fn == nil {
+		panic("attempted to set a nil encoder function")
+	}
+	encoders[encoding] = fn
+}
 
 var defaultContentTypes = map[string]struct{}{
 	"text/html":                {},
@@ -57,11 +117,13 @@ func Compress(level int, types ...string) func(next http.Handler) http.Handler {
 
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
+			encoder, encoding := selectEncoder(r.Header)
 			mcw := &maybeCompressResponseWriter{
 				ResponseWriter: w,
 				w:              w,
 				contentTypes:   contentTypes,
-				encoding:       selectEncoding(r.Header),
+				encoder:        encoder,
+				encoding:       encoding,
 				level:          level,
 			}
 			defer mcw.Close()
@@ -73,55 +135,46 @@ func Compress(level int, types ...string) func(next http.Handler) http.Handler {
 	}
 }
 
-func selectEncoding(h http.Header) encoding {
-	enc := h.Get("Accept-Encoding")
+func selectEncoder(h http.Header) (EncoderFunc, string) {
+	header := h.Get("Accept-Encoding")
 
-	switch {
-	// TODO:
-	// case "lzma":  // Opera.
-	// case "sdch":  // Chrome, Android. Gzip output + dictionary header.
-
-	case strings.Contains(enc, "br"):
-		return encodingBrotli
-
-	case strings.Contains(enc, "gzip"):
-		// TODO: Exception for old MSIE browsers that can't handle non-HTML?
-		// https://zoompf.com/blog/2012/02/lose-the-wait-http-compression
-		return encodingGzip
-
-	case strings.Contains(enc, "deflate"):
-		// HTTP 1.1 "deflate" (RFC 2616) stands for DEFLATE data (RFC 1951)
-		// wrapped with zlib (RFC 1950). The zlib wrapper uses Adler-32
-		// checksum compared to CRC-32 used in "gzip" and thus is faster.
-		//
-		// But.. some old browsers (MSIE, Safari 5.1) incorrectly expect
-		// raw DEFLATE data only, without the mentioned zlib wrapper.
-		// Because of this major confusion, most modern browsers try it
-		// both ways, first looking for zlib headers.
-		// Quote by Mark Adler: http://stackoverflow.com/a/9186091/385548
-		//
-		// The list of browsers having problems is quite big, see:
-		// http://zoompf.com/blog/2012/02/lose-the-wait-http-compression
-		// https://web.archive.org/web/20120321182910/http://www.vervestudios.co/projects/compression-tests/results
-		//
-		// That's why we prefer gzip over deflate. It's just more reliable
-		// and not significantly slower than gzip.
-		return encodingDeflate
-
-		// NOTE: Not implemented, intentionally:
-		// case "compress": // LZW. Deprecated.
-		// case "bzip2":    // Too slow on-the-fly.
-		// case "zopfli":   // Too slow on-the-fly.
-		// case "xz":       // Too slow on-the-fly.
+	// Parse the names of all accepted algorithms from the header.
+	var accepted []string
+	for _, m := range acceptEncodingAlgorithmsRe.FindAllStringSubmatch(header, -1) {
+		accepted = append(accepted, m[1])
 	}
 
-	return encodingNone
+	sort.Sort(byPerformance(accepted))
+
+	// Select the first mutually supported algorithm.
+	for _, name := range accepted {
+		if fn, ok := encoders[name]; ok {
+			return fn, name
+		}
+	}
+	return nil, ""
+}
+
+type byPerformance []string
+
+func (l byPerformance) Len() int      { return len(l) }
+func (l byPerformance) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l byPerformance) Less(i, j int) bool {
+	// Higher number = higher preference. This causes unknown names, which map
+	// to 0, to always be less prefered.
+	scores := map[string]int{
+		"br":      3,
+		"gzip":    2,
+		"deflate": 1,
+	}
+	return scores[l[i]] > scores[l[j]]
 }
 
 type maybeCompressResponseWriter struct {
 	http.ResponseWriter
 	w            io.Writer
-	encoding     encoding
+	encoder      EncoderFunc
+	encoding     string
 	contentTypes map[string]struct{}
 	level        int
 	wroteHeader  bool
@@ -153,31 +206,11 @@ func (w *maybeCompressResponseWriter) WriteHeader(code int) {
 		return
 	}
 
-	// Select the compress writer.
-	switch w.encoding {
-	case encodingBrotli:
-		params := brotli_enc.NewBrotliParams()
-		params.SetQuality(w.level)
-		w.w = brotli_enc.NewBrotliWriter(params, w.ResponseWriter)
-		w.ResponseWriter.Header().Set("Content-Encoding", "br")
-
-	case encodingGzip:
-		gw, err := gzip.NewWriterLevel(w.ResponseWriter, w.level)
-		if err != nil {
-			w.w = w.ResponseWriter
-			return
+	if w.encoder != nil && w.encoding != "" {
+		if wr := w.encoder(w.ResponseWriter, w.level); wr != nil {
+			w.w = wr
+			w.Header().Set("Content-Encoding", w.encoding)
 		}
-		w.w = gw
-		w.ResponseWriter.Header().Set("Content-Encoding", "gzip")
-
-	case encodingDeflate:
-		dw, err := flate.NewWriter(w.ResponseWriter, w.level)
-		if err != nil {
-			w.w = w.ResponseWriter
-			return
-		}
-		w.w = dw
-		w.ResponseWriter.Header().Set("Content-Encoding", "deflate")
 	}
 }
 
@@ -220,4 +253,20 @@ func (w *maybeCompressResponseWriter) Close() error {
 		return c.Close()
 	}
 	return errors.New("chi/middleware: io.WriteCloser is unavailable on the writer")
+}
+
+func encoderGzip(w http.ResponseWriter, level int) io.Writer {
+	gw, err := gzip.NewWriterLevel(w, level)
+	if err != nil {
+		return nil
+	}
+	return gw
+}
+
+func encoderDeflate(w http.ResponseWriter, level int) io.Writer {
+	dw, err := flate.NewWriter(w, level)
+	if err != nil {
+		return nil
+	}
+	return dw
 }


### PR DESCRIPTION
This patch adds support for Google's Brotli compression format currently [supported](https://caniuse.com/#search=brotli) by Chrome, Firefox and IE edge.