### PR TITLE
Update rest example to fix #314, nil pointer dereference

### DIFF
--- a/_examples/rest/main.go
+++ b/_examples/rest/main.go
@@ -328,6 +328,16 @@ type ArticleRequest struct {
 }
 
 func (a *ArticleRequest) Bind(r *http.Request) error {
+	// a.Article is nil if no Article fields are sent in the request. Return an
+	// error to avoid a nil pointer dereference.
+	if a.Article == nil {
+		return errors.New("missing required Article fields.")
+	}
+
+	// a.User is nil if no Userpayload fields are sent in the request. In this app
+	// this won't cause a panic, but checks in this Bind method may be required if
+	// a.User or futher nested fields like a.User.Name are accessed elsewhere.
+
 	// just a post-process after a decode..
 	a.ProtectedID = ""                                 // unset the protected ID
 	a.Article.Title = strings.ToLower(a.Article.Title) // as an example, we down-case


### PR DESCRIPTION
As discussed in issue #314, I've updated the rest example to include code and comments that address nil pointer dereferences. This may be particularly useful for new gophers that rely on the example to get them started (such as myself).