### PR TITLE
Remove go.mod, stick to +incompatible versions for v3.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,0 @@
-module github.com/go-chi/chi


### PR DESCRIPTION
It's better to live without go.mod file, since chi was already v3.x before the Go modules support. See discussion at https://github.com/go-chi/chi/issues/302.

Assuming we release v3.3.3 tag:

## Current master:
```
$ GO111MODULE=on go get github.com/go-chi/chi@v3.3.3
go: finding github.com/go-chi/chi v0.0.0-20180826211853-0dd0f5c3134
```
(adds **github.com/go-chi/chi v0.0.0-20180826211853-0dd0f5c3134f** into go.mod file)

## With this PR merged:
```
$ GO111MODULE=on go get github.com/go-chi/chi@v3.3.3
go: finding github.com/go-chi/chi v3.3.3
```
(adds **github.com/go-chi/chi v3.3.3+incompatible** into go.mod file)

## Summary
`v3.3.3+incompatible` looks much more cleaner than release chi as "v1" Go module. Imho, it'd be weird to release v1 module, since we're tagging with v3 version already.

If we ever release v4, we can add go.mod file with `/v4` import path suffix.