### PR TITLE
Fix leftover Goji reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 
 install:
   - go get -u golang.org/x/tools/cmd/goimports
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
 
 script:
   - go get -d -t ./...

--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -22,7 +22,7 @@ var xRealIP = http.CanonicalHeaderKey("X-Real-IP")
 // You should only use this middleware if you can trust the headers passed to
 // you (in particular, the two headers this middleware uses), for example
 // because you have placed a reverse proxy like HAProxy or nginx in front of
-// Goji. If your reverse proxies are configured to pass along arbitrary header
+// chi. If your reverse proxies are configured to pass along arbitrary header
 // values from the client, or if you use this middleware without a reverse
 // proxy, malicious clients will be able to make you very sad (or, depending on
 // how you're using RemoteAddr, vulnerable to an attack of some sort).


### PR DESCRIPTION
I found a leftover Goji reference in the real IP middleware docs.