### PR TITLE
Exported HTTP method names to avoid manual entry

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -36,14 +36,14 @@ var mALL = mCONNECT | mDELETE | mGET | mHEAD |
 // that require a litteral method name such as Method and MethodFunc
 const (
 	CONNECT = "CONNECT"
-	DELETE = "DELETE"
-	GET = "GET"
-	HEAD = "HEAD"
+	DELETE  = "DELETE"
+	GET     = "GET"
+	HEAD    = "HEAD"
 	OPTIONS = "OPTIONS"
-	PATCH = "PATCH"
-	POST = "POST"
-	PUT = "PUT"
-	TRACE = "TRACE"
+	PATCH   = "PATCH"
+	POST    = "POST"
+	PUT     = "PUT"
+	TRACE   = "TRACE"
 )
 
 var methodMap = map[string]methodTyp{

--- a/tree.go
+++ b/tree.go
@@ -32,30 +32,16 @@ const (
 var mALL = mCONNECT | mDELETE | mGET | mHEAD |
 	mOPTIONS | mPATCH | mPOST | mPUT | mTRACE
 
-// Exported http method names for help when calling functions
-// that require a litteral method name such as Method and MethodFunc
-const (
-	CONNECT = "CONNECT"
-	DELETE  = "DELETE"
-	GET     = "GET"
-	HEAD    = "HEAD"
-	OPTIONS = "OPTIONS"
-	PATCH   = "PATCH"
-	POST    = "POST"
-	PUT     = "PUT"
-	TRACE   = "TRACE"
-)
-
 var methodMap = map[string]methodTyp{
-	CONNECT: mCONNECT,
-	DELETE:  mDELETE,
-	GET:     mGET,
-	HEAD:    mHEAD,
-	OPTIONS: mOPTIONS,
-	PATCH:   mPATCH,
-	POST:    mPOST,
-	PUT:     mPUT,
-	TRACE:   mTRACE,
+	http.MethodConnect: mCONNECT,
+	http.MethodDelete:  mDELETE,
+	http.MethodGet:     mGET,
+	http.MethodHead:    mHEAD,
+	http.MethodOptions: mOPTIONS,
+	http.MethodPatch:   mPATCH,
+	http.MethodPost:    mPOST,
+	http.MethodPut:     mPUT,
+	http.MethodTrace:   mTRACE,
 }
 
 // RegisterMethod adds support for custom HTTP method handlers, available

--- a/tree.go
+++ b/tree.go
@@ -32,16 +32,30 @@ const (
 var mALL = mCONNECT | mDELETE | mGET | mHEAD |
 	mOPTIONS | mPATCH | mPOST | mPUT | mTRACE
 
+// Exported http method names for help when calling functions
+// that require a litteral method name such as Method and MethodFunc
+const (
+	CONNECT = "CONNECT"
+	DELETE = "DELETE"
+	GET = "GET"
+	HEAD = "HEAD"
+	OPTIONS = "OPTIONS"
+	PATCH = "PATCH"
+	POST = "POST"
+	PUT = "PUT"
+	TRACE = "TRACE"
+)
+
 var methodMap = map[string]methodTyp{
-	"CONNECT": mCONNECT,
-	"DELETE":  mDELETE,
-	"GET":     mGET,
-	"HEAD":    mHEAD,
-	"OPTIONS": mOPTIONS,
-	"PATCH":   mPATCH,
-	"POST":    mPOST,
-	"PUT":     mPUT,
-	"TRACE":   mTRACE,
+	CONNECT: mCONNECT,
+	DELETE:  mDELETE,
+	GET:     mGET,
+	HEAD:    mHEAD,
+	OPTIONS: mOPTIONS,
+	PATCH:   mPATCH,
+	POST:    mPOST,
+	PUT:     mPUT,
+	TRACE:   mTRACE,
 }
 
 // RegisterMethod adds support for custom HTTP method handlers, available


### PR DESCRIPTION
Added exported http method names for use when calling functions that require manually entering the method name such as Method and MethodFunc to avoid syntax errors plus it defines which methods are supported. Also avoid having devs create their own method constants.

Used all caps for the names to avoid conflicts with the existing exported functions with the same names.