### PR TITLE
Bump module version to v3 (again) now that support is backported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: go
 
 go:
-  - 1.7.x
-  - 1.8.x
   - 1.9.x
   - 1.10.x
   - 1.11.x
 
 install:
-  - go get -u golang.org/x/tools/cmd/goimports
+  - GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
+
+env:
+  - GO111MODULE=on
 
 script:
   - go get -d -t ./...

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ package main
 
 import (
 	"net/http"
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 func main() {
@@ -77,8 +77,8 @@ of chi and serve as a good form of documentation.
 import (
   //...
   "context"
-  "github.com/go-chi/chi"
-  "github.com/go-chi/chi/middleware"
+  "github.com/go-chi/chi/v3"
+  "github.com/go-chi/chi/v3/middleware"
 )
 
 func main() {

--- a/_examples/custom-handler/main.go
+++ b/_examples/custom-handler/main.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 type Handler func(w http.ResponseWriter, r *http.Request) error

--- a/_examples/custom-method/main.go
+++ b/_examples/custom-method/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v3"
+	"github.com/go-chi/chi/v3/middleware"
 )
 
 func init() {

--- a/_examples/fileserver/main.go
+++ b/_examples/fileserver/main.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 func main() {

--- a/_examples/graceful/main.go
+++ b/_examples/graceful/main.go
@@ -8,8 +8,8 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v3"
+	"github.com/go-chi/chi/v3/middleware"
 	"github.com/go-chi/valve"
 )
 

--- a/_examples/hello-world/main.go
+++ b/_examples/hello-world/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v3"
+	"github.com/go-chi/chi/v3/middleware"
 )
 
 func main() {

--- a/_examples/limits/main.go
+++ b/_examples/limits/main.go
@@ -24,8 +24,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v3"
+	"github.com/go-chi/chi/v3/middleware"
 )
 
 func main() {

--- a/_examples/logging/main.go
+++ b/_examples/logging/main.go
@@ -17,8 +17,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v3"
+	"github.com/go-chi/chi/v3/middleware"
 	"github.com/sirupsen/logrus"
 )
 

--- a/_examples/rest/main.go
+++ b/_examples/rest/main.go
@@ -47,8 +47,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v3"
+	"github.com/go-chi/chi/v3/middleware"
 	"github.com/go-chi/docgen"
 	"github.com/go-chi/render"
 )
@@ -105,7 +105,7 @@ func main() {
 	if *routes {
 		// fmt.Println(docgen.JSONRoutesDoc(r))
 		fmt.Println(docgen.MarkdownRoutesDoc(r, docgen.MarkdownOpts{
-			ProjectPath: "github.com/go-chi/chi",
+			ProjectPath: "github.com/go-chi/chi/v3",
 			Intro:       "Welcome to the chi/_examples/rest generated docs.",
 		}))
 		return

--- a/_examples/router-walk/main.go
+++ b/_examples/router-walk/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 func main() {

--- a/_examples/todos-resource/main.go
+++ b/_examples/todos-resource/main.go
@@ -11,8 +11,8 @@ package main
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v3"
+	"github.com/go-chi/chi/v3/middleware"
 )
 
 func main() {

--- a/_examples/todos-resource/todos.go
+++ b/_examples/todos-resource/todos.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 type todosResource struct{}

--- a/_examples/todos-resource/users.go
+++ b/_examples/todos-resource/users.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 type usersResource struct{}

--- a/_examples/versions/main.go
+++ b/_examples/versions/main.go
@@ -14,12 +14,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/_examples/versions/data"
-	"github.com/go-chi/chi/_examples/versions/presenter/v1"
-	"github.com/go-chi/chi/_examples/versions/presenter/v2"
-	"github.com/go-chi/chi/_examples/versions/presenter/v3"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v3"
+	"github.com/go-chi/chi/v3/_examples/versions/data"
+	"github.com/go-chi/chi/v3/_examples/versions/presenter/apiv1"
+	"github.com/go-chi/chi/v3/_examples/versions/presenter/apiv2"
+	"github.com/go-chi/chi/v3/_examples/versions/presenter/apiv3"
+	"github.com/go-chi/chi/v3/middleware"
 	"github.com/go-chi/render"
 )
 
@@ -88,11 +88,11 @@ func listArticles(w http.ResponseWriter, r *http.Request) {
 			apiVersion := r.Context().Value("api.version").(string)
 			switch apiVersion {
 			case "v1":
-				articles <- v1.NewArticleResponse(article)
+				articles <- apiv1.NewArticleResponse(article)
 			case "v2":
-				articles <- v2.NewArticleResponse(article)
+				articles <- apiv2.NewArticleResponse(article)
 			default:
-				articles <- v3.NewArticleResponse(article)
+				articles <- apiv3.NewArticleResponse(article)
 			}
 
 			time.Sleep(100 * time.Millisecond)
@@ -133,11 +133,11 @@ func getArticle(w http.ResponseWriter, r *http.Request) {
 	apiVersion := r.Context().Value("api.version").(string)
 	switch apiVersion {
 	case "v1":
-		payload = v1.NewArticleResponse(article)
+		payload = apiv1.NewArticleResponse(article)
 	case "v2":
-		payload = v2.NewArticleResponse(article)
+		payload = apiv2.NewArticleResponse(article)
 	default:
-		payload = v3.NewArticleResponse(article)
+		payload = apiv3.NewArticleResponse(article)
 	}
 
 	render.Render(w, r, payload)

--- a/_examples/versions/presenter/apiv1/article.go
+++ b/_examples/versions/presenter/apiv1/article.go
@@ -1,9 +1,9 @@
-package v1
+package apiv1
 
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/_examples/versions/data"
+	"github.com/go-chi/chi/v3/_examples/versions/data"
 )
 
 // Article presented in API version 1.

--- a/_examples/versions/presenter/apiv2/article.go
+++ b/_examples/versions/presenter/apiv2/article.go
@@ -1,10 +1,10 @@
-package v2
+package apiv2
 
 import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-chi/chi/_examples/versions/data"
+	"github.com/go-chi/chi/v3/_examples/versions/data"
 )
 
 // Article presented in API version 2.

--- a/_examples/versions/presenter/apiv3/article.go
+++ b/_examples/versions/presenter/apiv3/article.go
@@ -1,11 +1,11 @@
-package v3
+package apiv3
 
 import (
 	"fmt"
 	"math/rand"
 	"net/http"
 
-	"github.com/go-chi/chi/_examples/versions/data"
+	"github.com/go-chi/chi/v3/_examples/versions/data"
 )
 
 // Article presented in API version 2.

--- a/chi.go
+++ b/chi.go
@@ -9,8 +9,8 @@
 //  import (
 //  	"net/http"
 //
-//  	"github.com/go-chi/chi"
-//  	"github.com/go-chi/chi/middleware"
+//  	"github.com/go-chi/chi/v3"
+//  	"github.com/go-chi/chi/v3/middleware"
 //  )
 //
 //  func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/go-chi/chi/v3
+
+require (
+	golang.org/x/net v0.0.0-20180926154720-4dfa2610cdf3
+	golang.org/x/text v0.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.0.0-20180926154720-4dfa2610cdf3 h1:dgd4x4kJt7G4k4m93AYLzM8Ni6h2qLTfh9n9vXJT3/0=
+golang.org/x/net v0.0.0-20180926154720-4dfa2610cdf3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/middleware/content_charset_test.go
+++ b/middleware/content_charset_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 func TestContentCharset(t *testing.T) {

--- a/middleware/get_head.go
+++ b/middleware/get_head.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 // GetHead automatically route undefined HEAD requests to GET handlers.

--- a/middleware/get_head_test.go
+++ b/middleware/get_head_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 func TestGetHead(t *testing.T) {

--- a/middleware/profiler.go
+++ b/middleware/profiler.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 // Profiler is a convenient subrouter used for mounting net/http/pprof. ie.

--- a/middleware/realip_test.go
+++ b/middleware/realip_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 func TestXRealIP(t *testing.T) {

--- a/middleware/strip.go
+++ b/middleware/strip.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 // StripSlashes is a middleware that will match request paths with a trailing

--- a/middleware/strip_test.go
+++ b/middleware/strip_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 func TestStripSlashes(t *testing.T) {

--- a/middleware/throttle_test.go
+++ b/middleware/throttle_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 var testContent = []byte("Hello world!")

--- a/middleware/url_format.go
+++ b/middleware/url_format.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/v3"
 )
 
 var (


### PR DESCRIPTION
Hello,

Discussion in #302 concluded by removing support for Go Modules (without the "incompatible" workaround) because the `/v3` suffix was only supported by users of vgo. However, since then limited support for importing using the version suffix has been backported to older versions of Go (including 1.9.7+ and 1.10.3+). For more information see here: https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher

I would like to request that the `/v3` suffix be added back to the module and the import path.
This does require that support for Go 1.7 and 1.8 be dropped, but they haven't been supported for several versions anyways.

This will also (EDIT: this should have read **NOT break**) break existing import paths, which was another reason it was reverted previously, however, since it's an easy update I am hoping you will reconsider now that it is supported,

Thank you for your consideration.