### PR TITLE
Add no-transform to NoCache middleware

### DIFF
--- a/middleware/nocache.go
+++ b/middleware/nocache.go
@@ -14,7 +14,7 @@ var epoch = time.Unix(0, 0).Format(time.RFC1123)
 // Taken from https://github.com/mytrile/nocache
 var noCacheHeaders = map[string]string{
 	"Expires":         epoch,
-	"Cache-Control":   "no-cache, no-store, must-revalidate, private, max-age=0",
+	"Cache-Control":   "no-cache, no-store, no-transform, must-revalidate, private, max-age=0",
 	"Pragma":          "no-cache",
 	"X-Accel-Expires": "0",
 }


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Other:

No transformations or conversions should be made to the resource. The Content-Encoding, Content-Range, Content-Type headers must not be modified by a proxy. A non- transparent proxy might, for example, convert between image formats in order to save cache space or to reduce the amount of traffic on a slow link. The no-transform directive disallows this.