### PR TITLE
add a middleware to change post method to "_method" in HTML form

### DIFF
--- a/middleware/change_to_hidden_method.go
+++ b/middleware/change_to_hidden_method.go
@@ -1,0 +1,24 @@
+package middleware
+
+import "net/http"
+
+func ChangePostToHiddenMethod(next http.Handler) http.Handler {
+	var changeableMethods = map[string]bool{
+		http.MethodPut:    true,
+		http.MethodDelete: true,
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		method := r.FormValue("_method")
+		if ok := changeableMethods[method]; ok {
+			r.Method = method
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/middleware/change_to_hidden_method_test.go
+++ b/middleware/change_to_hidden_method_test.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi"
+)
+
+func TestChangePostToHiddenMethod(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(ChangePostToHiddenMethod)
+	r.Post("/post", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("post"))
+	})
+	r.Put("/put", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("put"))
+	})
+	r.Delete("/delete", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("delete"))
+	})
+
+	tests := []struct {
+		method             string
+		path               string
+		body               url.Values
+		expectedStatusCode int
+		expectedBody       string
+	}{
+		{
+			http.MethodPost,
+			"/post",
+			url.Values{},
+			http.StatusOK,
+			"post",
+		},
+		{
+			http.MethodPut,
+			"/put",
+			url.Values{
+				"_method": {"PUT"},
+			},
+			http.StatusOK,
+			"put",
+		},
+		{
+			http.MethodDelete,
+			"/delete",
+			url.Values{
+				"_method": {"DELETE"},
+			},
+			http.StatusOK,
+			"delete",
+		},
+	}
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+	for _, test := range tests {
+		resp, body := testRequest(t, ts, test.method, test.path, nil)
+		if resp.StatusCode != test.expectedStatusCode {
+			t.Errorf("unexpected status code: got %d, but expected %d\n", resp.StatusCode, test.expectedStatusCode)
+		}
+		if body != test.expectedBody {
+			t.Errorf("unexpected body: got %s, but expected %s\n", body, test.expectedBody)
+		}
+	}
+}


### PR DESCRIPTION
This middleware enables us to request with other methods than GET and POST from HTML form.
In order to change to these methods, 
add (hidden) input named "_method" in POST form and set desired method to the value.
eg)

```html
<form action="/articles/1" method="POST">
    <input type="hidden" name="_method" value="PUT">
</form>
```

```go
r := chi.NewRouter()
r.Use(ChangePostToHiddenMethod)
r.Put("/articles/{id}", func(w http.ResponseWriter, r *http.Request) {
    // do something
})
```

Now, the changeable methods are PUT and DELETE.