### PR TITLE
using consts for HTTP methods from net/http package

### DIFF
--- a/middleware/get_head.go
+++ b/middleware/get_head.go
@@ -9,7 +9,7 @@ import (
 // GetHead automatically route undefined HEAD requests to GET handlers.
 func GetHead(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "HEAD" {
+		if r.Method == http.MethodHead {
 			rctx := chi.RouteContext(r.Context())
 			routePath := rctx.RoutePath
 			if routePath == "" {
@@ -26,8 +26,8 @@ func GetHead(next http.Handler) http.Handler {
 			// Attempt to find a HEAD handler for the routing path, if not found, traverse
 			// the router as through its a GET route, but proceed with the request
 			// with the HEAD method.
-			if !rctx.Routes.Match(tctx, "HEAD", routePath) {
-				rctx.RouteMethod = "GET"
+			if !rctx.Routes.Match(tctx, http.MethodHead, routePath) {
+				rctx.RouteMethod = http.MethodGet
 				rctx.RoutePath = routePath
 				next.ServeHTTP(w, r)
 				return

--- a/middleware/heartbeat.go
+++ b/middleware/heartbeat.go
@@ -12,7 +12,7 @@ import (
 func Heartbeat(endpoint string) func(http.Handler) http.Handler {
 	f := func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == "GET" && strings.EqualFold(r.URL.Path, endpoint) {
+			if r.Method == http.MethodGet && strings.EqualFold(r.URL.Path, endpoint) {
 				w.Header().Set("Content-Type", "text/plain")
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte("."))


### PR DESCRIPTION
Hi! I guess, there is make sense to use HTTP method names from `net/http` package instead self defined. What do you think?