### PR TITLE
add Chme to README.md as an auxiliary middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Please see https://github.com/go-chi for additional packages.
 | [httpcoala](https://github.com/go-chi/httpcoala)   | HTTP request coalescer                                      |
 | [chi-authz](https://github.com/casbin/chi-authz)   | Request ACL via https://github.com/hsluoyz/casbin           |
 | [phi](https://github.com/fate-lovely/phi)          | Port chi to [fasthttp](https://github.com/valyala/fasthttp) |
+| [chme](https://github.com/tomocy/chme)          | Change Post To Other methods in HTML form|
 --------------------------------------------------------------------------------------------------------------------
 
 please [submit a PR](./CONTRIBUTING.md) if you'd like to include a link to a chi-compatible middleware


### PR DESCRIPTION
[Chme](https://github.com/tomocy/chme) is a middleware which change POST to other methods set in HTML form such as PUT, DELETE.
I hope that this will help chi work as a RESTful server also from HTML form.