### PR TITLE
Resolve Possible Panic for Out of Range URLParam

### DIFF
--- a/context.go
+++ b/context.go
@@ -71,7 +71,10 @@ func (x *Context) Reset() {
 func (x *Context) URLParam(key string) string {
 	for k := len(x.URLParams.Keys) - 1; k >= 0; k-- {
 		if x.URLParams.Keys[k] == key {
-			return x.URLParams.Values[k]
+			if len(x.URLParams.Values)-1 >= k {
+				return x.URLParams.Values[k]
+			}
+			return ""
 		}
 	}
 	return ""

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,50 @@
+package chi
+
+import "testing"
+
+func TestURLParam(t *testing.T) {
+	t.Run("should return corresponding value if key exists", func(t *testing.T) {
+		ctx := NewRouteContext()
+		ctx.URLParams.Add("key1", "value1")
+		ctx.URLParams.Add("key2", "value2")
+
+		t.Run("should return corresponding value given the first key", func(t *testing.T) {
+			got := ctx.URLParam("key1")
+			expect := "value1"
+			if got != expect {
+				t.Errorf("got %v, expected %v", got, expect)
+			}
+		})
+
+		t.Run("should return corresponding value given the last key", func(t *testing.T) {
+			got := ctx.URLParam("key2")
+			expect := "value2"
+			if got != expect {
+				t.Errorf("got %v, expected %v", got, expect)
+			}
+		})
+	})
+
+	t.Run("should return empty string if key does not exist", func(t *testing.T) {
+		ctx := NewRouteContext()
+		ctx.URLParams.Add("key1", "value1")
+		ctx.URLParams.Add("key2", "value2")
+
+		got := ctx.URLParam("key3")
+		expect := ""
+		if got != expect {
+			t.Errorf("got %v, expected %v", got, expect)
+		}
+	})
+
+	t.Run("should return empty string if value is out of range", func(t *testing.T) {
+		ctx := NewRouteContext()
+		ctx.URLParams.Keys = append(ctx.URLParams.Keys, "key1")
+
+		got := ctx.URLParam("key1")
+		expect := ""
+		if got != expect {
+			t.Errorf("got %v, expected %v", got, expect)
+		}
+	})
+}


### PR DESCRIPTION
This is related to #277. Added tests to confirm the fix is correct.

This panic should not be possible if this was written with good encapsulation. Unfortunately users might be able to manipulate the values directly (like in the test case) and that usage could cause a panic.