### PR TITLE
middleware: fixes #409 to encode only content-types in allowedTypes

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -322,6 +322,7 @@ func (cw *compressResponseWriter) WriteHeader(code int) {
 
 	// Is the content type compressable?
 	if _, ok := cw.contentTypes[contentType]; !ok {
+		cw.w = cw.ResponseWriter
 		return
 	}
 

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -152,12 +152,12 @@ func TestCompressor(t *testing.T) {
 	})
 
 	r.Get("/getcss", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Type", "text/css")
 		w.Write([]byte("textstring"))
 	})
 
 	r.Get("/getplain", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Type", "text/plain")
 		w.Write([]byte("textstring"))
 	})
 
@@ -206,6 +206,12 @@ func TestCompressor(t *testing.T) {
 			path:              "/getcss",
 			acceptedEncodings: []string{"nop, gzip, deflate"},
 			expectedEncoding:  "nop",
+		},
+		{
+			name:              "content type is not allowed",
+			path:              "/getplain",
+			acceptedEncodings: []string{"gzip", "deflate"},
+			expectedEncoding:  "",
 		},
 	}
 


### PR DESCRIPTION
#409 #410

I want to fix this problem before next major release...