### PR TITLE
middleware: set Vary header if compressed

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -327,6 +327,7 @@ func (cw *compressResponseWriter) WriteHeader(code int) {
 
 	if cw.encoding != "" {
 		cw.Header().Set("Content-Encoding", cw.encoding)
+		cw.Header().Set("Vary", "Accept-Encoding")
 
 		// The content-length after compression is unknown
 		cw.Header().Del("Content-Length")


### PR DESCRIPTION
Hi, thanks for useful middlewares.

I want to set `Vary` header like Apache's mod_deflate.
https://www.fastly.com/blog/best-practices-using-vary-header