### PR TITLE
adding a configurable request id middleware

### DIFF
--- a/_examples/versions/main.go
+++ b/_examples/versions/main.go
@@ -79,9 +79,9 @@ func listArticles(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		for i := 1; i <= 10; i++ {
 			article := &data.Article{
-				ID:                     i,
-				Title:                  fmt.Sprintf("Article #%v", i),
-				Data:                   []string{"one", "two", "three", "four"},
+				ID:    i,
+				Title: fmt.Sprintf("Article #%v", i),
+				Data:  []string{"one", "two", "three", "four"},
 				CustomDataForAuthUsers: "secret data for auth'd users only",
 			}
 
@@ -111,9 +111,9 @@ func getArticle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	article := &data.Article{
-		ID:                     1,
-		Title:                  "Article #1",
-		Data:                   []string{"one", "two", "three", "four"},
+		ID:    1,
+		Title: "Article #1",
+		Data:  []string{"one", "two", "three", "four"},
 		CustomDataForAuthUsers: "secret data for auth'd users only",
 	}
 

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+)
+
+func TestXRequestId(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Add("X-Request-Id", "testing")
+	w := httptest.NewRecorder()
+
+	r := chi.NewRouter()
+	// r.Use(RequestID)
+	r.Use(ConfiguredRequestID("X-Request-Id"))
+
+	requestID := ""
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		requestID = GetReqID(r.Context())
+		w.Write([]byte("Hello World"))
+	})
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatal("Response Code should be 200")
+	}
+
+	if requestID != "testing" {
+		t.Fatal("Test copy existing requestID error.")
+	}
+}
+
+func TestGenerateXRequestId(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	r := chi.NewRouter()
+	// r.Use(RequestID)
+	r.Use(ConfiguredRequestID("X-Request-Id"))
+
+	requestID := ""
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		requestID = GetReqID(r.Context())
+		w.Write([]byte("Hello World"))
+	})
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatal("Response Code should be 200")
+	}
+
+	if requestID == "" {
+		t.Fatalf("Test generated requestID error. :%s", requestID)
+	}
+}
+
+func TestCustomHeaderXRequestId(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Add("X-Custom-Request-Id", "testing")
+	w := httptest.NewRecorder()
+
+	r := chi.NewRouter()
+	r.Use(ConfiguredRequestID("X-Custom-Request-Id"))
+
+	requestID := ""
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		requestID = GetReqID(r.Context())
+		w.Write([]byte("Hello World"))
+	})
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatal("Response Code should be 200")
+	}
+
+	if requestID != "testing" {
+		t.Fatalf("Test generated requestID error. :%s", requestID)
+	}
+}


### PR DESCRIPTION
For our project we want to use a different header to track our request id.
This change adds a new method that wraps the current one to allow you to
configure the header like so:

r.Use(middleware.ConfigurableRequestID("my-header"))