### PR TITLE
middleware: Avoid masking multiple calls to WriteHeader

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -308,6 +308,7 @@ type compressResponseWriter struct {
 
 func (cw *compressResponseWriter) WriteHeader(code int) {
 	if cw.wroteHeader {
+		cw.ResponseWriter.WriteHeader(code) // Allow multiple calls to propagate.
 		return
 	}
 	cw.wroteHeader = true

--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -70,12 +70,12 @@ func (b *basicWriter) WriteHeader(code int) {
 	if !b.wroteHeader {
 		b.code = code
 		b.wroteHeader = true
-		b.ResponseWriter.WriteHeader(code)
 	}
+	b.ResponseWriter.WriteHeader(code)
 }
 
 func (b *basicWriter) Write(buf []byte) (int, error) {
-	b.WriteHeader(http.StatusOK)
+	b.maybeWriteHeader()
 	n, err := b.ResponseWriter.Write(buf)
 	if b.tee != nil {
 		_, err2 := b.tee.Write(buf[:n])


### PR DESCRIPTION
This PR fixes two instances of `WriteHeader` call propagation being masked by a `wroteHeader` check.

The current behavior could potentially mask some bugs in handlers. Say we want to write error `500` to the user, but `200` has already been written at some earlier point in time. As a result, the user would see `200` and think everything is OK, and we would not necessarily know about it.

Typically `net/http` would output the following in such instances:

```
2019/06/06 15:17:45 http: superfluous response.WriteHeader call from [...]`
```

Which gives us a chance to react to these bugs.