### PR TITLE
Simplify code

### DIFF
--- a/context.go
+++ b/context.go
@@ -125,8 +125,8 @@ type RouteParams struct {
 
 // Add will append a URL parameter to the end of the route param
 func (s *RouteParams) Add(key, value string) {
-	(*s).Keys = append((*s).Keys, key)
-	(*s).Values = append((*s).Values, value)
+	s.Keys = append(s.Keys, key)
+	s.Values = append(s.Values, value)
 }
 
 // ServerBaseContext wraps an http.Handler to set the request context to the

--- a/tree.go
+++ b/tree.go
@@ -698,7 +698,7 @@ func patNextSegment(pattern string) (nodeTyp, string, string, byte, int, int) {
 				rexpat = "^" + rexpat
 			}
 			if rexpat[len(rexpat)-1] != '$' {
-				rexpat = rexpat + "$"
+				rexpat += "$"
 			}
 		}
 


### PR DESCRIPTION
- We can access the pointer members directly
- Easier to read concatenation