### PR TITLE
Fixed encoding test

### DIFF
--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -19,7 +19,7 @@ func testRequestWithAcceptedEncodings(t *testing.T, ts *httptest.Server, method,
 		t.Fatal(err)
 		return nil, ""
 	}
-	if len(encodings) >= 0 {
+	if len(encodings) > 0 {
 		encodingsString := strings.Join(encodings, ",")
 		req.Header.Set("Accept-Encoding", encodingsString)
 	}


### PR DESCRIPTION
len(encodings) will always be >= 0, which is probably just a typo.
Set the header only when there really is an encoding setting present.