### PR TITLE
middleware: RequestID - Define Header

### DIFF
--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -20,6 +20,10 @@ type ctxKeyRequestID int
 // RequestIDKey is the key that holds the unique request ID in a request context.
 const RequestIDKey ctxKeyRequestID = 0
 
+// RequestIDHeader is the name of the HTTP Header which contains the request id.
+// Exported so that it can be changed by developers
+var RequestIDHeader = "X-Request-Id"
+
 var prefix string
 var reqid uint64
 
@@ -63,7 +67,7 @@ func init() {
 func RequestID(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		requestID := r.Header.Get("X-Request-Id")
+		requestID := r.Header.Get(RequestIDHeader)
 		if requestID == "" {
 			myid := atomic.AddUint64(&reqid, 1)
 			requestID = fmt.Sprintf("%s-%06d", prefix, myid)

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+)
+
+func maintainDefaultRequestId() func() {
+	original := RequestIDHeader
+
+	return func() {
+		RequestIDHeader = original
+	}
+}
+
+func TestRequestID(t *testing.T) {
+	tests := map[string]struct {
+		requestIDHeader  string
+		request          func() *http.Request
+		expectedResponse string
+	}{
+		"Retrieves Request Id from default header": {
+			"X-Request-Id",
+			func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Add("X-Request-Id", "req-123456")
+
+				return req
+			},
+			"RequestID: req-123456",
+		},
+		"Retrieves Request Id from custom header": {
+			"X-Trace-Id",
+			func() *http.Request {
+				req, _ := http.NewRequest("GET", "/", nil)
+				req.Header.Add("X-Trace-Id", "trace:abc123")
+
+				return req
+			},
+			"RequestID: trace:abc123",
+		},
+	}
+
+	defer maintainDefaultRequestId()()
+
+	for _, test := range tests {
+		w := httptest.NewRecorder()
+
+		r := chi.NewRouter()
+
+		RequestIDHeader = test.requestIDHeader
+
+		r.Use(RequestID)
+
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			requestID := GetReqID(r.Context())
+			response := fmt.Sprintf("RequestID: %s", requestID)
+
+			w.Write([]byte(response))
+		})
+		r.ServeHTTP(w, test.request())
+
+		if w.Body.String() != test.expectedResponse {
+			t.Fatalf("RequestID was not the expected value")
+		}
+	}
+}


### PR DESCRIPTION
The RequestID middleware had the Header name hardcoded within the middleware function. This PR creates and exports a variable `RequestIDHeader` which will allow developers to define the header which will contain the RequestID.