### PR TITLE
documented Handlers map key

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -795,6 +795,7 @@ func (ns nodes) findEdge(label byte) *node {
 }
 
 // Route describes the details of a routing handler.
+// Handlers map key is an HTTP method
 type Route struct {
 	Pattern   string
 	Handlers  map[string]http.Handler


### PR DESCRIPTION
As it's not immediately clear what is used as key in Handlers map, I added a line to document it.