### PR TITLE
middleware: suppress http.ErrAbortHandler in recoverer

### DIFF
--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -18,7 +18,7 @@ import (
 func Recoverer(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
-			if rvr := recover(); rvr != nil {
+			if rvr := recover(); rvr != nil && rvr != http.ErrAbortHandler {
 
 				logEntry := GetLogEntry(r)
 				if logEntry != nil {


### PR DESCRIPTION
This PR suppresses panic handling and logging for http.ErrAbortHandler visible when recoverer middleware is used along `httputil.ReverseProxy`. This err is handled natively in stdlib's http package, so it's safe to let it passthrough

Happy to add a tests for this middleware, along with test case for this particular scenario. 

Does Chi have a compatibility promise with go1.7? If so, wrapping that with build tags will be required, as this sentinel error was added in go1.8 (happy to handle that)

Related issues:
https://github.com/golang/go/issues/28239
https://github.com/golang/go/issues/23643

This might be relevant for @VojtechVitek as he has created one of the issues