### PR TITLE
middleware: explicitly stop timer

### DIFF
--- a/middleware/throttle.go
+++ b/middleware/throttle.go
@@ -85,10 +85,12 @@ func (t *throttler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, errTimedOut, http.StatusServiceUnavailable)
 			return
 		case <-ctx.Done():
+			timer.Stop()
 			http.Error(w, errContextCanceled, http.StatusServiceUnavailable)
 			return
 		case tok := <-t.tokens:
 			defer func() {
+				timer.Stop()
 				t.tokens <- tok
 			}()
 			t.h.ServeHTTP(w, r)


### PR DESCRIPTION
In the throttle middleware the timer does not being released until it reaches the given timeout. Because of this a high CPU usage can occur and also the GC is not able to recover the Timer from the memory.

Related issue: [#448](https://github.com/go-chi/chi/issues/448)