### PR TITLE
Make fileserver example a little more elaborate

### DIFF
--- a/_examples/fileserver/main.go
+++ b/_examples/fileserver/main.go
@@ -12,25 +12,29 @@ import (
 func main() {
 	r := chi.NewRouter()
 
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("hi"))
-	})
+	basePath := "/sub"
 
-	workDir, _ := os.Getwd()
-	filesDir := filepath.Join(workDir, "files")
-	FileServer(r, "/files", http.Dir(filesDir))
+	r.Route(basePath, func(root chi.Router) {
+		root.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("hi"))
+		})
+
+		workDir, _ := os.Getwd()
+		filesDir := filepath.Join(workDir, "files")
+		FileServer(root, basePath, "/files", http.Dir(filesDir))
+	})
 
 	http.ListenAndServe(":3333", r)
 }
 
 // FileServer conveniently sets up a http.FileServer handler to serve
 // static files from a http.FileSystem.
-func FileServer(r chi.Router, path string, root http.FileSystem) {
+func FileServer(r chi.Router, basePath string, path string, root http.FileSystem) {
 	if strings.ContainsAny(path, "{}*") {
 		panic("FileServer does not permit URL parameters.")
 	}
 
-	fs := http.StripPrefix(path, http.FileServer(root))
+	fs := http.StripPrefix(basePath+path, http.FileServer(root))
 
 	if path != "/" && path[len(path)-1] != '/' {
 		r.Get(path, http.RedirectHandler(path+"/", 301).ServeHTTP)


### PR DESCRIPTION
While it's trivial to remove the basePath from the code, it wasn't quite obvious to me which paths I had to strip where to make the fileserver work if not mounted to /.