### PR TITLE
AllowContentEncoding middleware

### DIFF
--- a/middleware/content_encoding.go
+++ b/middleware/content_encoding.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// AllowContentEncoding enforces a whitelist of request Content-Encoding otherwise responds
+// with a 415 Unsupported Media Type status.
+func AllowContentEncoding(contentEncoding ...string) func(next http.Handler) http.Handler {
+	allowedEncodings := make(map[string]struct{}, len(contentEncoding))
+	for _, encoding := range contentEncoding {
+		allowedEncodings[strings.TrimSpace(strings.ToLower(encoding))] = struct{}{}
+	}
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			requestEncodings := r.Header["Content-Encoding"]
+			// skip check for empty content body or no Content-Encoding
+			if r.ContentLength == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+			// All encodings in the request must be allowed
+			for _, encoding := range requestEncodings {
+				if _, ok := allowedEncodings[strings.TrimSpace(strings.ToLower(encoding))]; !ok {
+					w.WriteHeader(http.StatusUnsupportedMediaType)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/middleware/content_encoding_test.go
+++ b/middleware/content_encoding_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+)
+
+func TestContentEncodingMiddleware(t *testing.T) {
+	t.Parallel()
+
+	// support for:
+	// Content-Encoding: gzip
+	// Content-Encoding: deflate
+	// Content-Encoding: gzip, deflate
+	// Content-Encoding: deflate, gzip
+	middleware := AllowContentEncoding("deflate", "gzip")
+
+	tests := []struct {
+		name           string
+		encodings      []string
+		expectedStatus int
+	}{
+		{
+			name:           "Support no encoding",
+			encodings:      []string{},
+			expectedStatus: 200,
+		},
+		{
+			name:           "Support gzip encoding",
+			encodings:      []string{"gzip"},
+			expectedStatus: 200,
+		},
+		{
+			name:           "No support for br encoding",
+			encodings:      []string{"br"},
+			expectedStatus: 415,
+		},
+		{
+			name:           "Support for gzip and deflate encoding",
+			encodings:      []string{"gzip", "deflate"},
+			expectedStatus: 200,
+		},
+		{
+			name:           "Support for deflate and gzip encoding",
+			encodings:      []string{"deflate", "gzip"},
+			expectedStatus: 200,
+		},
+		{
+			name:           "No support for deflate and br encoding",
+			encodings:      []string{"deflate", "br"},
+			expectedStatus: 415,
+		},
+	}
+
+	for _, tt := range tests {
+		var tt = tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := []byte("This is my content. There are many like this but this one is mine")
+			r := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+			for _, encoding := range tt.encodings {
+				r.Header.Set("Content-Encoding", encoding)
+			}
+
+			w := httptest.NewRecorder()
+			router := chi.NewRouter()
+			router.Use(middleware)
+			router.Post("/", func(w http.ResponseWriter, r *http.Request) {})
+
+			router.ServeHTTP(w, r)
+			res := w.Result()
+			if res.StatusCode != tt.expectedStatus {
+				t.Errorf("response is incorrect, got %d, want %d", w.Code, tt.expectedStatus)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- `AllowContentEncoding` provides support to whitelist a set of content encodings checking `Content-Encoding` header same way `chi` checks can whitelist content types using `AllowContentType` middleware
- `Content-Encoding` header may have more than one encoding listed in the order they were applied. the server should support all of them in order to process the request.
- Context:
    - https://tools.ietf.org/html/rfc7231#section-3.1.2.2
    - https://tools.ietf.org/html/rfc7230#section-4.2
