### PR TITLE
AllowContentType middleware refactor and tests

### DIFF
--- a/middleware/content_type.go
+++ b/middleware/content_type.go
@@ -19,9 +19,9 @@ func SetHeader(key, value string) func(next http.Handler) http.Handler {
 // AllowContentType enforces a whitelist of request Content-Types otherwise responds
 // with a 415 Unsupported Media Type status.
 func AllowContentType(contentTypes ...string) func(next http.Handler) http.Handler {
-	allowedContentTypes := make(map[string]bool, len(contentTypes))
+	allowedContentTypes := make(map[string]struct{}, len(contentTypes))
 	for _, ctype := range contentTypes {
-		allowedContentTypes[strings.TrimSpace(strings.ToLower(ctype))] = true
+		allowedContentTypes[strings.TrimSpace(strings.ToLower(ctype))] = struct{}{}
 	}
 
 	return func(next http.Handler) http.Handler {
@@ -37,7 +37,7 @@ func AllowContentType(contentTypes ...string) func(next http.Handler) http.Handl
 				s = s[0:i]
 			}
 
-			if allowedContentTypes[s] {
+			if _, ok := allowedContentTypes[s]; ok {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/middleware/content_type.go
+++ b/middleware/content_type.go
@@ -19,9 +19,9 @@ func SetHeader(key, value string) func(next http.Handler) http.Handler {
 // AllowContentType enforces a whitelist of request Content-Types otherwise responds
 // with a 415 Unsupported Media Type status.
 func AllowContentType(contentTypes ...string) func(next http.Handler) http.Handler {
-	cT := []string{}
-	for _, t := range contentTypes {
-		cT = append(cT, strings.ToLower(t))
+	allowedContentTypes := make(map[string]bool, len(contentTypes))
+	for _, ctype := range contentTypes {
+		allowedContentTypes[strings.TrimSpace(strings.ToLower(ctype))] = true
 	}
 
 	return func(next http.Handler) http.Handler {
@@ -37,11 +37,9 @@ func AllowContentType(contentTypes ...string) func(next http.Handler) http.Handl
 				s = s[0:i]
 			}
 
-			for _, t := range cT {
-				if t == s {
-					next.ServeHTTP(w, r)
-					return
-				}
+			if allowedContentTypes[s] {
+				next.ServeHTTP(w, r)
+				return
 			}
 
 			w.WriteHeader(http.StatusUnsupportedMediaType)

--- a/middleware/content_type_test.go
+++ b/middleware/content_type_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+)
+
+func TestContentType(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		name                string
+		inputValue          string
+		allowedContentTypes []string
+		want                int
+	}{
+		{
+			"should accept requests with a matching content type",
+			"application/json; charset=UTF-8",
+			[]string{"application/json"},
+			http.StatusOK,
+		},
+		{
+			"should accept requests with a matching content type no charset",
+			"application/json",
+			[]string{"application/json"},
+			http.StatusOK,
+		},
+		{
+			"should accept requests with a matching content-type with extra values",
+			"application/json; foo=bar; charset=UTF-8; spam=eggs",
+			[]string{"application/json"},
+			http.StatusOK,
+		},
+		{
+			"should accept requests with a matching content type when multiple content types are supported",
+			"text/xml; charset=UTF-8",
+			[]string{"application/json", "text/xml"},
+			http.StatusOK,
+		},
+		{
+			"should not accept requests with a mismatching content type",
+			"text/plain; charset=latin-1",
+			[]string{"application/json"},
+			http.StatusUnsupportedMediaType,
+		},
+		{
+			"should not accept requests with a mismatching content type even if multiple content types are allowed",
+			"text/plain; charset=Latin-1",
+			[]string{"application/json", "text/xml"},
+			http.StatusUnsupportedMediaType,
+		},
+	}
+
+	for _, tt := range tests {
+		var tt = tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+
+			r := chi.NewRouter()
+			r.Use(AllowContentType(tt.allowedContentTypes...))
+			r.Post("/", func(w http.ResponseWriter, r *http.Request) {})
+
+			body := []byte("This is my content. There are many like this but this one is mine")
+			req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+			req.Header.Set("Content-Type", tt.inputValue)
+
+			r.ServeHTTP(recorder, req)
+			res := recorder.Result()
+
+			if res.StatusCode != tt.want {
+				t.Errorf("response is incorrect, got %d, want %d", recorder.Code, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- adds tests for `AllowContentType` middleware
- use map for better lookup performance