### PR TITLE
Include Allow header in 405 Method Not Allowed response. Closes #446

### DIFF
--- a/context.go
+++ b/context.go
@@ -42,8 +42,8 @@ type Context struct {
 	// intentionally unexported so it cant be tampered.
 	routeParams RouteParams
 
-	// methodNotAllowed hint
-	methodNotAllowed bool
+	// methodNotAllowed list of allowed methods
+	methodNotAllowed []string
 }
 
 // NewRouteContext returns a new routing Context object.
@@ -63,7 +63,7 @@ func (x *Context) Reset() {
 	x.routePattern = ""
 	x.routeParams.Keys = x.routeParams.Keys[:0]
 	x.routeParams.Values = x.routeParams.Values[:0]
-	x.methodNotAllowed = false
+	x.methodNotAllowed = nil
 }
 
 // URLParam returns the corresponding URL parameter value from the request

--- a/tree.go
+++ b/tree.go
@@ -44,6 +44,16 @@ var methodMap = map[string]methodTyp{
 	http.MethodTrace:   mTRACE,
 }
 
+var reversedMethodMap = reverseMethodMap(methodMap)
+
+func reverseMethodMap(m map[string]methodTyp) map[methodTyp]string {
+	reversed := make(map[methodTyp]string, len(m))
+	for k, v := range m {
+		reversed[v] = k
+	}
+	return reversed
+}
+
 // RegisterMethod adds support for custom HTTP method handlers, available
 // via Router#Method and Router#MethodFunc
 func RegisterMethod(method string) {
@@ -468,7 +478,13 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 
 				// flag that the routing context found a route, but not a corresponding
 				// supported method
-				rctx.methodNotAllowed = true
+				allowedMethods := make([]string, len(xn.endpoints))
+				i := 0
+				for m, _ := range xn.endpoints {
+					allowedMethods[i] = reversedMethodMap[m]
+					i++
+				}
+				rctx.methodNotAllowed = allowedMethods
 			}
 		}
 
@@ -606,8 +622,8 @@ func (n *node) routes() []Route {
 				if h.handler == nil {
 					continue
 				}
-				m := methodTypString(mt)
-				if m == "" {
+				m, ok := reversedMethodMap[mt]
+				if !ok {
 					continue
 				}
 				hs[m] = h.handler
@@ -744,15 +760,6 @@ func longestPrefix(k1, k2 string) int {
 		}
 	}
 	return i
-}
-
-func methodTypString(method methodTyp) string {
-	for s, t := range methodMap {
-		if method == t {
-			return s
-		}
-	}
-	return ""
 }
 
 type nodes []*node

--- a/tree.go
+++ b/tree.go
@@ -480,9 +480,11 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 				// supported method
 				allowedMethods := make([]string, len(xn.endpoints))
 				i := 0
-				for m, _ := range xn.endpoints {
-					allowedMethods[i] = reversedMethodMap[m]
-					i++
+				for method, mtype := range methodMap {
+					if _, ok := xn.endpoints[mtype]; ok {
+						allowedMethods[i] = method
+						i++
+					}
 				}
 				rctx.methodNotAllowed = allowedMethods
 			}


### PR DESCRIPTION
- Include `Allow` Header for `405 MethodNotAllowed` responses. Context [RFC](https://tools.ietf.org/html/rfc7231#section-6.5.5)
- Include tests for default `methodNotAllowed` handler
- improve performance in the [node routes](https://github.com/go-chi/chi/compare/master...bernardopericacho:allow_header?expand=1#diff-37cf0fd7a164303538a2d22d965646dfR625) checking existence on a map instead of doing a loop calling [`methodTypString`](https://github.com/go-chi/chi/compare/master...bernardopericacho:allow_header?expand=1#diff-37cf0fd7a164303538a2d22d965646dfL750)