### PR TITLE
add sentry-go middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Please see https://github.com/go-chi for additional packages.
 | [httpcoala](https://github.com/go-chi/httpcoala)   | HTTP request coalescer                                      |
 | [chi-authz](https://github.com/casbin/chi-authz)   | Request ACL via https://github.com/hsluoyz/casbin           |
 | [phi](https://github.com/fate-lovely/phi)          | Port chi to [fasthttp](https://github.com/valyala/fasthttp) |
+| [scout](https://github.com/zy4/scout)              | [sentry-go handler](https://github.com/getsentry/sentry-go) |
 --------------------------------------------------------------------------------------------------------------------
 
 please [submit a PR](./CONTRIBUTING.md) if you'd like to include a link to a chi-compatible middleware


### PR DESCRIPTION
This PR adds a community [middleware](https://www.github.com/zy4/scout) to the README.