### PR TITLE
Retry-After HTTP header in Throttle middleware

### DIFF
--- a/middleware/throttle.go
+++ b/middleware/throttle.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -15,35 +16,49 @@ var (
 	defaultBacklogTimeout = time.Second * 60
 )
 
+// ThrottleOpts represents a set of throttling options.
+type ThrottleOpts struct {
+	Limit          int
+	BacklogLimit   int
+	BacklogTimeout time.Duration
+	RetryAfterFn   func(ctxDone bool) time.Duration
+}
+
 // Throttle is a middleware that limits number of currently processed requests
 // at a time across all users. Note: Throttle is not a rate-limiter per user,
 // instead it just puts a ceiling on the number of currentl in-flight requests
 // being processed from the point from where the Throttle middleware is mounted.
 func Throttle(limit int) func(http.Handler) http.Handler {
-	return ThrottleBacklog(limit, 0, defaultBacklogTimeout)
+	return ThrottleWithOpts(ThrottleOpts{Limit: limit, BacklogTimeout: defaultBacklogTimeout})
 }
 
 // ThrottleBacklog is a middleware that limits number of currently processed
 // requests at a time and provides a backlog for holding a finite number of
 // pending requests.
 func ThrottleBacklog(limit int, backlogLimit int, backlogTimeout time.Duration) func(http.Handler) http.Handler {
-	if limit < 1 {
+	return ThrottleWithOpts(ThrottleOpts{Limit: limit, BacklogLimit: backlogLimit, BacklogTimeout: backlogTimeout})
+}
+
+// ThrottleWithOpts is a middleware that limits number of currently processed requests using passed ThrottleOpts.
+func ThrottleWithOpts(opts ThrottleOpts) func(http.Handler) http.Handler {
+	if opts.Limit < 1 {
 		panic("chi/middleware: Throttle expects limit > 0")
 	}
 
-	if backlogLimit < 0 {
+	if opts.BacklogLimit < 0 {
 		panic("chi/middleware: Throttle expects backlogLimit to be positive")
 	}
 
 	t := throttler{
-		tokens:         make(chan token, limit),
-		backlogTokens:  make(chan token, limit+backlogLimit),
-		backlogTimeout: backlogTimeout,
+		tokens:         make(chan token, opts.Limit),
+		backlogTokens:  make(chan token, opts.Limit+opts.BacklogLimit),
+		backlogTimeout: opts.BacklogTimeout,
+		retryAfterFn:   opts.RetryAfterFn,
 	}
 
 	// Filling tokens.
-	for i := 0; i < limit+backlogLimit; i++ {
-		if i < limit {
+	for i := 0; i < opts.Limit+opts.BacklogLimit; i++ {
+		if i < opts.Limit {
 			t.tokens <- token{}
 		}
 		t.backlogTokens <- token{}
@@ -56,6 +71,7 @@ func ThrottleBacklog(limit int, backlogLimit int, backlogTimeout time.Duration) 
 			select {
 
 			case <-ctx.Done():
+				t.setRetryAfterHeaderIfNeeded(w, true)
 				http.Error(w, errContextCanceled, http.StatusServiceUnavailable)
 				return
 
@@ -68,10 +84,12 @@ func ThrottleBacklog(limit int, backlogLimit int, backlogTimeout time.Duration) 
 
 				select {
 				case <-timer.C:
+					t.setRetryAfterHeaderIfNeeded(w, false)
 					http.Error(w, errTimedOut, http.StatusServiceUnavailable)
 					return
 				case <-ctx.Done():
 					timer.Stop()
+					t.setRetryAfterHeaderIfNeeded(w, true)
 					http.Error(w, errContextCanceled, http.StatusServiceUnavailable)
 					return
 				case tok := <-t.tokens:
@@ -84,6 +102,7 @@ func ThrottleBacklog(limit int, backlogLimit int, backlogTimeout time.Duration) 
 				return
 
 			default:
+				t.setRetryAfterHeaderIfNeeded(w, false)
 				http.Error(w, errCapacityExceeded, http.StatusServiceUnavailable)
 				return
 			}
@@ -101,4 +120,13 @@ type throttler struct {
 	tokens         chan token
 	backlogTokens  chan token
 	backlogTimeout time.Duration
+	retryAfterFn   func(ctxDone bool) time.Duration
+}
+
+// setRetryAfterHeaderIfNeeded sets Retry-After HTTP header if corresponding retryAfterFn option of throttler is initialized.
+func (t throttler) setRetryAfterHeaderIfNeeded(w http.ResponseWriter, ctxDone bool) {
+	if t.retryAfterFn == nil {
+		return
+	}
+	w.Header().Set("Retry-After", strconv.Itoa(int(t.retryAfterFn(ctxDone).Seconds())))
 }


### PR DESCRIPTION
I think it would be good to be able to set a "Retry-After" HTTP header for response with 503 status code in `Throttle` middleware when the limit is exceeded. Thus, the HTTP client will know after how long it can repeat the request.

I need this in a several projects, probably it will be useful for someone else.