### PR TITLE
tree.go: check if ntParam, ntRegexp was found

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -172,7 +172,7 @@ func TestMuxBasic(t *testing.T) {
 
 	// GET /ping//poop
 	// Issue 426
-	if _, body := testRequest(t, ts, "GET", "/ping//poop", nil); body != "poop." {
+	if resp, body := testRequest(t, ts, "GET", "/ping//poop", nil); resp.StatusCode != 404 {
 		t.Fatalf(body)
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -417,6 +417,8 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 				continue
 			}
 
+			found := false
+
 			// serially loop through each node grouped by the tail delimiter
 			for idx := 0; idx < len(nds); idx++ {
 				xn = nds[idx]
@@ -441,9 +443,14 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 					continue
 				}
 
+				found = true
 				rctx.routeParams.Values = append(rctx.routeParams.Values, xsearch[:p])
 				xsearch = xsearch[p:]
 				break
+			}
+
+			if !found {
+				continue
 			}
 
 		default:


### PR DESCRIPTION
maybe this will fix #426 .

Since the current `(*node).findRoute` does not check, If there is a route like `r.Get('/url/{param:(\\w+)}/test', f)` and get request `/url//test` (don't match), Router calls `f` and causes the bug.

Forked from #476 and fixed it, so if this PR will be merged, please also close #476 .