### PR TITLE
Flush compressed streams

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -382,9 +382,23 @@ func (cw *compressResponseWriter) writer() io.Writer {
 	}
 }
 
+type compressFlusher interface {
+	Flush() error
+}
+
 func (cw *compressResponseWriter) Flush() {
 	if f, ok := cw.writer().(http.Flusher); ok {
 		f.Flush()
+	}
+	// If the underlying writer has a compression flush signature,
+	// call this Flush() method instead
+	if f, ok := cw.writer().(compressFlusher); ok {
+		f.Flush()
+
+		// Also flush the underlying response writer
+		if f, ok := cw.ResponseWriter.(http.Flusher); ok {
+			f.Flush()
+		}
 	}
 }
 


### PR DESCRIPTION
When using stream compression in combination with (SSE) event streams, you need to flush every time you sent an event (to ensure data still in the compression buffer is effectively sent).

The compression middleware's Flush doesn't flush compressed data, because the underlying writer (e.g. gzip.Writer)'s Flush doesn't have the http.Flusher signature (because it has an error return argument). 

This patch flushes the underlying stream if it implements gzip's flush signature. 

After flushing the GZip stream, the underlying response writer will have pending data as well, and so needs to be flushed too.