### PR TITLE
fix: handle methodnotallowed with path variables

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -452,6 +452,10 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 							rctx.routeParams.Keys = append(rctx.routeParams.Keys, h.paramKeys...)
 							return xn
 						}
+
+						// flag that the routing context found a route, but not a corresponding
+						// supported method
+						rctx.methodNotAllowed = true
 					}
 				}
 


### PR DESCRIPTION
Currently, any route with a pathvariable will return a 404 on a method not allowed condition when it should return a 405. This adds the necessary bool setting to the route context for the path variable case.

We noticed this when we upgraded from v4.0.1 to v4.1.1. A little git bisect magic later, and it turned out to be in some of the regex additions. Repeating the setting of the rctx.methodNotAllowed boolean looked like the most straightforward approach. 