### PR TITLE
Replace wildcards correctly in RoutePattern

### DIFF
--- a/_examples/fileserver/main.go
+++ b/_examples/fileserver/main.go
@@ -63,8 +63,7 @@ func FileServer(r chi.Router, path string, root http.FileSystem) {
 
 	r.Get(path, func(w http.ResponseWriter, r *http.Request) {
 		rctx := chi.RouteContext(r.Context())
-		// Trailing /* is already removed by the RoutePattern func
-		pathPrefix := rctx.RoutePattern()
+		pathPrefix := strings.TrimSuffix(rctx.RoutePattern(), "/*")
 		fs := http.StripPrefix(pathPrefix, http.FileServer(root))
 		fs.ServeHTTP(w, r)
 	})

--- a/_examples/fileserver/main.go
+++ b/_examples/fileserver/main.go
@@ -63,7 +63,8 @@ func FileServer(r chi.Router, path string, root http.FileSystem) {
 
 	r.Get(path, func(w http.ResponseWriter, r *http.Request) {
 		rctx := chi.RouteContext(r.Context())
-		pathPrefix := strings.TrimSuffix(rctx.RoutePattern(), "/*")
+		// Trailing /* is already removed by the RoutePattern func
+		pathPrefix := rctx.RoutePattern()
 		fs := http.StripPrefix(pathPrefix, http.FileServer(root))
 		fs.ServeHTTP(w, r)
 	})

--- a/context.go
+++ b/context.go
@@ -93,7 +93,7 @@ func (x *Context) URLParam(key string) string {
 //   }
 func (x *Context) RoutePattern() string {
 	routePattern := strings.Join(x.RoutePatterns, "")
-	return strings.ReplaceAll(routePattern, "/*", "")
+	return strings.Replace(routePattern, "/*", "", -1)
 }
 
 // RouteContext returns chi's routing Context object from a

--- a/context.go
+++ b/context.go
@@ -93,7 +93,7 @@ func (x *Context) URLParam(key string) string {
 //   }
 func (x *Context) RoutePattern() string {
 	routePattern := strings.Join(x.RoutePatterns, "")
-	return strings.Replace(routePattern, "/*/", "/", -1)
+	return strings.ReplaceAll(routePattern, "/*", "")
 }
 
 // RouteContext returns chi's routing Context object from a

--- a/context.go
+++ b/context.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"regexp"
 	"strings"
 )
 
 var (
 	// RouteCtxKey is the context.Context key to store the request context.
-	RouteCtxKey   = &contextKey{"RouteContext"}
-	wildcardRx, _ = regexp.Compile(`\/\*\/`)
+	RouteCtxKey = &contextKey{"RouteContext"}
 )
 
 // Context is the default routing context set on the root node of a
@@ -98,15 +96,14 @@ func (x *Context) RoutePattern() string {
 	return replaceWildcards(routePattern)
 }
 
-// replaceWildcards takes a path and recursively replaces all occurrences of
-// "/*/" to "/".
+// replaceWildcards takes a route pattern and recursively replaces all
+// occurrences of "/*/" to "/".
 func replaceWildcards(p string) string {
-	if !wildcardRx.Match([]byte(p)) {
-		return p
+	if strings.Contains(p, "/*/") {
+		return replaceWildcards(strings.Replace(p, "/*/", "/", -1))
 	}
 
-	p = wildcardRx.ReplaceAllString(p, "/")
-	return replaceWildcards(p)
+	return p
 }
 
 // RouteContext returns chi's routing Context object from a

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,62 @@
+package chi
+
+import "testing"
+
+// TestRoutePattern tests correct wildcard removals.
+// If user organizes a router like this:
+//
+// (router.go)
+// r.Route("/v1", func(r chi.Router) {
+// 	r.Mount("/resources", resourcesController{}.Router())
+// }
+//
+// (resources_controller.go)
+// r.Route("/", func(r chi.Router) {
+// 	r.Get("/{resource_id}", getResource())
+// }
+//
+// The route pattern could be "/v1/resources/*/resource_id" instead of "/v1/resources/resource_id"
+// This test makes sure wildcards are removed correctly.
+func TestRoutePattern(t *testing.T) {
+	routePatterns := []string{
+		"/v1",
+		"/resources/*",
+		"/resource_id",
+	}
+
+	x := &Context{
+		RoutePatterns: routePatterns,
+	}
+
+	if p := x.RoutePattern(); p != "/v1/resources/resource_id" {
+		t.Fatal("unexpected route path: " + p)
+	}
+
+	x.RoutePatterns = []string{
+		"/v1",
+		"/resources/*",
+		// Additional wildcard, depending on the router structure of the user
+		"/*",
+		"/resource_id",
+	}
+
+	// Correctly removes wildcards instead of "/v1/resources/*/resource_id"
+	if p := x.RoutePattern(); p != "/v1/resources/resource_id" {
+		t.Fatal("unexpected route path: " + p)
+	}
+
+	x.RoutePatterns = []string{
+		"/v1",
+		"/resources/*",
+		// Even with many wildcards
+		"/*",
+		"/*",
+		"/*",
+		"/resource_id/*", // And trailing wildcard
+	}
+
+	// Correctly removes wildcards instead of "/v1/resources/*/*/resource_id/*"
+	if p := x.RoutePattern(); p != "/v1/resources/resource_id" {
+		t.Fatal("unexpected route path: " + p)
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -13,23 +13,24 @@ import "testing"
 // (resources_controller.go)
 // r.Route("/", func(r chi.Router) {
 // 	r.Get("/{resource_id}", getResource())
+// 	other routes...
 // }
 //
-// The route pattern could be "/v1/resources/*/resource_id" instead of "/v1/resources/resource_id"
+// The route pattern could be "/v1/resources/*/{resource_id}" instead of "/v1/resources/{resource_id}"
 // This test makes sure wildcards are removed correctly.
 func TestRoutePattern(t *testing.T) {
 	routePatterns := []string{
 		"/v1",
 		"/resources/*",
-		"/resource_id",
+		"/{resource_id}",
 	}
 
 	x := &Context{
 		RoutePatterns: routePatterns,
 	}
 
-	if p := x.RoutePattern(); p != "/v1/resources/resource_id" {
-		t.Fatal("unexpected route path: " + p)
+	if p := x.RoutePattern(); p != "/v1/resources/{resource_id}" {
+		t.Fatal("unexpected route pattern: " + p)
 	}
 
 	x.RoutePatterns = []string{
@@ -37,12 +38,12 @@ func TestRoutePattern(t *testing.T) {
 		"/resources/*",
 		// Additional wildcard, depending on the router structure of the user
 		"/*",
-		"/resource_id",
+		"/{resource_id}",
 	}
 
-	// Correctly removes wildcards instead of "/v1/resources/*/resource_id"
-	if p := x.RoutePattern(); p != "/v1/resources/resource_id" {
-		t.Fatal("unexpected route path: " + p)
+	// Correctly removes wildcards instead of "/v1/resources/*/{resource_id}"
+	if p := x.RoutePattern(); p != "/v1/resources/{resource_id}" {
+		t.Fatal("unexpected route pattern: " + p)
 	}
 
 	x.RoutePatterns = []string{
@@ -52,11 +53,11 @@ func TestRoutePattern(t *testing.T) {
 		"/*",
 		"/*",
 		"/*",
-		"/resource_id/*", // And trailing wildcard
+		"/{resource_id}/*", // And trailing wildcard
 	}
 
-	// Correctly removes wildcards instead of "/v1/resources/*/*/resource_id/*"
-	if p := x.RoutePattern(); p != "/v1/resources/resource_id" {
-		t.Fatal("unexpected route path: " + p)
+	// Correctly removes wildcards instead of "/v1/resources/*/*/{resource_id}/*"
+	if p := x.RoutePattern(); p != "/v1/resources/{resource_id}" {
+		t.Fatal("unexpected route pattern: " + p)
 	}
 }


### PR DESCRIPTION
In case there are many `/*/` next to each other, this PR
Replaces all occurrences leaving the RoutePattern w/out
any wildcard.