### PR TITLE
Add port number to RealIP middleware

### DIFF
--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -4,6 +4,7 @@ package middleware
 // https://github.com/zenazn/goji/tree/master/web/middleware
 
 import (
+	"net"
 	"net/http"
 	"strings"
 )
@@ -29,7 +30,7 @@ var xRealIP = http.CanonicalHeaderKey("X-Real-IP")
 func RealIP(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		if rip := realIP(r); rip != "" {
-			r.RemoteAddr = rip
+			r.RemoteAddr = net.JoinHostPort(rip, "0")
 		}
 		h.ServeHTTP(w, r)
 	}

--- a/middleware/realip_test.go
+++ b/middleware/realip_test.go
@@ -8,50 +8,69 @@ import (
 	"github.com/go-chi/chi"
 )
 
-func TestXRealIP(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/", nil)
-	req.Header.Add("X-Real-IP", "100.100.100.100")
-	w := httptest.NewRecorder()
-
-	r := chi.NewRouter()
-	r.Use(RealIP)
-
-	realIP := ""
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		realIP = r.RemoteAddr
-		w.Write([]byte("Hello World"))
-	})
-	r.ServeHTTP(w, req)
-
-	if w.Code != 200 {
-		t.Fatal("Response Code should be 200")
+func TestRealIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		header     http.Header
+		want       string
+	}{
+		{
+			"remote-addr",
+			"1.1.1.1:42",
+			nil,
+			"1.1.1.1:42",
+		},
+		{
+			"x-real-ip",
+			"1.1.1.1",
+			http.Header{"X-Real-Ip": {"100.100.100.100"}},
+			"100.100.100.100:0",
+		},
+		{
+			"x-real-ip-6",
+			"2001:beef::0",
+			http.Header{"X-Real-Ip": {"2001:dead::0"}},
+			"[2001:dead::0]:0",
+		},
+		{
+			"x-forwarded-for",
+			"1.1.1.1",
+			http.Header{"X-Forwarded-For": {"100.100.100.100"}},
+			"100.100.100.100:0",
+		},
+		{
+			"x-forwarded-for-6",
+			"2001:beef::0",
+			http.Header{"X-Forwarded-For": {"2001:dead::0"}},
+			"[2001:dead::0]:0",
+		},
 	}
 
-	if realIP != "100.100.100.100" {
-		t.Fatal("Test get real IP error.")
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			req.Header = tt.header
 
-func TestXForwardForIP(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/", nil)
-	req.Header.Add("X-Forwarded-For", "100.100.100.100")
-	w := httptest.NewRecorder()
+			w := httptest.NewRecorder()
+			r := chi.NewRouter()
+			r.Use(RealIP)
 
-	r := chi.NewRouter()
-	r.Use(RealIP)
+			realIP := ""
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				realIP = r.RemoteAddr
+				w.Write([]byte("Hello World"))
+			})
+			r.ServeHTTP(w, req)
 
-	realIP := ""
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		realIP = r.RemoteAddr
-		w.Write([]byte("Hello World"))
-	})
-	r.ServeHTTP(w, req)
+			if w.Code != 200 {
+				t.Fatalf("wrong response code: %d; wanted 200", w.Code)
+			}
 
-	if w.Code != 200 {
-		t.Fatal("Response Code should be 200")
-	}
-
-	if realIP != "100.100.100.100" {
-		t.Fatal("Test get real IP error.")
+			if realIP != tt.want {
+				t.Fatalf("wrong IP: %q; wanted %q", realIP, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #453

Downside: this is not entirely backwards compatible; e.g. my app will
actually break because it *assumes* you're running it behind a proxy and
won't remove the port. Then again, it already breaks for people not
using a proxy, but in certain scenarios (e.g. some closed source app)
that will probably never really happen.

So ... maybe something for v5? Just thought I'd open a PR in any case.