### PR TITLE
remove unnecessary type conversions

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -1756,6 +1756,7 @@ func BenchmarkMux(b *testing.B) {
 	mx.Get("/", h1)
 	mx.Get("/hi", h2)
 	mx.Get("/sup/{id}/and/{this}", h3)
+	mx.Get("/sup/{id}/{bar:foo}/{this}", h3)
 
 	mx.Route("/sharing/{x}/{hash}", func(mx Router) {
 		mx.Get("/", h4)          // subrouter-1
@@ -1771,6 +1772,7 @@ func BenchmarkMux(b *testing.B) {
 		"/",
 		"/hi",
 		"/sup/123/and/this",
+		"/sup/123/foo/this",
 		"/sharing/z/aBc",                 // subrouter-1
 		"/sharing/z/aBc/twitter",         // subrouter-1
 		"/sharing/z/aBc/direct",          // subrouter-2

--- a/tree.go
+++ b/tree.go
@@ -433,7 +433,7 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 				}
 
 				if ntyp == ntRegexp && xn.rex != nil {
-					if !xn.rex.Match([]byte(xsearch[:p])) {
+					if !xn.rex.MatchString(xsearch[:p]) {
 						continue
 					}
 				} else if strings.IndexByte(xsearch[:p], '/') != -1 {


### PR DESCRIPTION
```
name                              old time/op    new time/op
Mux/route:/sup/123/foo/this-8     1.24µs ± 0%    1.99µs ± 0%

name                              old alloc/op   new alloc/op
Mux/route:/sup/123/foo/this-8     456B ± 0%      448B ± 0%

name                              old allocs/op  new allocs/op
Mux/route:/sup/123/foo/this-8     4.00 ± 0%      3.00 ± 0%
```