### PR TITLE
Respond with 429 when throttled

### DIFF
--- a/middleware/throttle.go
+++ b/middleware/throttle.go
@@ -72,7 +72,7 @@ func ThrottleWithOpts(opts ThrottleOpts) func(http.Handler) http.Handler {
 
 			case <-ctx.Done():
 				t.setRetryAfterHeaderIfNeeded(w, true)
-				http.Error(w, errContextCanceled, http.StatusServiceUnavailable)
+				http.Error(w, errContextCanceled, http.StatusTooManyRequests)
 				return
 
 			case btok := <-t.backlogTokens:
@@ -85,12 +85,12 @@ func ThrottleWithOpts(opts ThrottleOpts) func(http.Handler) http.Handler {
 				select {
 				case <-timer.C:
 					t.setRetryAfterHeaderIfNeeded(w, false)
-					http.Error(w, errTimedOut, http.StatusServiceUnavailable)
+					http.Error(w, errTimedOut, http.StatusTooManyRequests)
 					return
 				case <-ctx.Done():
 					timer.Stop()
 					t.setRetryAfterHeaderIfNeeded(w, true)
-					http.Error(w, errContextCanceled, http.StatusServiceUnavailable)
+					http.Error(w, errContextCanceled, http.StatusTooManyRequests)
 					return
 				case tok := <-t.tokens:
 					defer func() {
@@ -103,7 +103,7 @@ func ThrottleWithOpts(opts ThrottleOpts) func(http.Handler) http.Handler {
 
 			default:
 				t.setRetryAfterHeaderIfNeeded(w, false)
-				http.Error(w, errCapacityExceeded, http.StatusServiceUnavailable)
+				http.Error(w, errCapacityExceeded, http.StatusTooManyRequests)
 				return
 			}
 		}

--- a/middleware/throttle_test.go
+++ b/middleware/throttle_test.go
@@ -134,7 +134,7 @@ func TestThrottleTriggerGatewayTimeout(t *testing.T) {
 
 			buf, err := ioutil.ReadAll(res.Body)
 			assertNoError(t, err)
-			assertEqual(t, http.StatusServiceUnavailable, res.StatusCode)
+			assertEqual(t, http.StatusTooManyRequests, res.StatusCode)
 			assertEqual(t, errTimedOut, strings.TrimSpace(string(buf)))
 
 		}(i)
@@ -194,7 +194,7 @@ func TestThrottleMaximum(t *testing.T) {
 
 			buf, err := ioutil.ReadAll(res.Body)
 			assertNoError(t, err)
-			assertEqual(t, http.StatusServiceUnavailable, res.StatusCode)
+			assertEqual(t, http.StatusTooManyRequests, res.StatusCode)
 			assertEqual(t, errCapacityExceeded, strings.TrimSpace(string(buf)))
 
 		}(i)
@@ -244,7 +244,7 @@ func TestThrottleRetryAfter(t *testing.T) {
 
 			res, err := client.Get(server.URL)
 			assertNoError(t, err)
-			assertEqual(t, http.StatusServiceUnavailable, res.StatusCode)
+			assertEqual(t, http.StatusTooManyRequests, res.StatusCode)
 			assertEqual(t, res.Header.Get("Retry-After"), "3600")
 		}(i)
 	}


### PR DESCRIPTION
Responding with `HTTP 429 Too Many Requests` status code seems more inline with what actually happened instead of the service unavailable response status code, because _technically_, the service is still available, it's just the sender has send too many requests in a given amount of time. (Typically a 400s error is client fault, whereas a 500s error is server).