### PR TITLE
Add extensibility to the Basic Auth middleware

### DIFF
--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -8,14 +8,14 @@ import (
 // Checks whether a user and password combination is allowed to authenticate with
 // the BasicAuthWithAuthenticator simple basic http auth middleware.
 type Authenticator interface {
-	checkPassword(user string, password string) bool
+	CheckPassword(user string, password string) bool
 }
 
 type MapAuthenticator struct {
 	creds map[string]string
 }
 
-func (authData MapAuthenticator) checkPassword(user string, password string) bool {
+func (authData MapAuthenticator) CheckPassword(user string, password string) bool {
 	credPass, credUserOk := authData.creds[user]
 	return credUserOk && password == credPass
 }
@@ -32,7 +32,7 @@ func BasicAuthWithAuthenticator(realm string, auth Authenticator) func(next http
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			user, pass, ok := r.BasicAuth()
-			if !ok || !auth.checkPassword(user, pass) {
+			if !ok || !auth.CheckPassword(user, pass) {
 				basicAuthFailed(w, realm)
 				return
 			}

--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -5,18 +5,34 @@ import (
 	"net/http"
 )
 
-// BasicAuth implements a simple middleware handler for adding basic http auth to a route.
+// Checks whether a user and password combination is allowed to authenticate with
+// the BasicAuthWithAuthenticator simple basic http auth middleware.
+type Authenticator interface {
+	checkPassword(user string, password string) bool
+}
+
+type MapAuthenticator struct {
+	creds map[string]string
+}
+
+func (authData MapAuthenticator) checkPassword(user string, password string) bool {
+	credPass, credUserOk := authData.creds[user]
+	return credUserOk && password == credPass
+}
+
+// BasicAuth implements a simple middleware handler for adding basic http auth to a route using
+// a map of allowed users and passwords.
 func BasicAuth(realm string, creds map[string]string) func(next http.Handler) http.Handler {
+	return BasicAuthWithAuthenticator(realm, MapAuthenticator{creds})
+}
+
+// BasicAuthWithAuthenticator implements a simple middleware handler for adding basic http auth
+// to a route using an implementor of thr Authenticator interface.
+func BasicAuthWithAuthenticator(realm string, auth Authenticator) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			user, pass, ok := r.BasicAuth()
-			if !ok {
-				basicAuthFailed(w, realm)
-				return
-			}
-
-			credPass, credUserOk := creds[user]
-			if !credUserOk || pass != credPass {
+			if !ok || !auth.checkPassword(user, pass) {
 				basicAuthFailed(w, realm)
 				return
 			}

--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi"
+)
+
+func TestBasicAuth(t *testing.T) {
+	realm := "myRealm"
+
+	acceptedCreds := map[string]string{
+		"gooduser": "goodpassword",
+	}
+
+	r := chi.NewRouter()
+	r.Use(BasicAuth(realm, acceptedCreds))
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello World"))
+	})
+
+	testAuth(t, r, "gooduser", "goodpassword", 200, nil)
+	testAuth(t, r, "gooduser", "badpassword", 401, &realm)
+	testAuth(t, r, "baduser", "goodpassword", 401, &realm)
+	testAuth(t, r, "baduser", "badpassword", 401, &realm)
+}
+
+func testAuth(t *testing.T, r *chi.Mux, user string, password string, expectedCode int, realm *string) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.SetBasicAuth(user, password)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != expectedCode {
+		t.Fatalf("With %s:%s expected status code to be %d but got %d", user, password,
+			expectedCode, w.Code)
+	}
+
+	if realm != nil {
+		expected := fmt.Sprintf("Basic realm=\"%s\"", *realm)
+		got := w.Header().Get("WWW-Authenticate")
+		if !strings.HasPrefix(got, expected) {
+			t.Fatalf("Expected WWW-Authenticate with realm '%s' but got '%s'", *realm, got)
+		}
+	}
+}


### PR DESCRIPTION
The existing Basic Auth middleware is extremely limiting. Due to thread safety issues with maps, it's not even possible to implement a feature like reloading a password file on SIGHUP.

This patch adds a great deal of extensibility to the Basic Auth middleware with a minimal amount of extra code through the addition of a simple Authenticator interface. It also adds unit tests.