### PR TITLE
Chops the Suffix rather than the Prefix

### DIFF
--- a/middleware/url_format.go
+++ b/middleware/url_format.go
@@ -53,7 +53,7 @@ func URLFormat(next http.Handler) http.Handler {
 
 		if strings.Index(path, ".") > 0 {
 			base := strings.LastIndex(path, "/")
-			idx := strings.Index(path[base:], ".")
+			idx := strings.LastIndex(path[base:], ".")
 
 			if idx > 0 {
 				idx += base

--- a/middleware/url_format_test.go
+++ b/middleware/url_format_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"github.com/go-chi/chi"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUrlFormat(t *testing.T) {
+	r := chi.NewRouter()
+
+	r.Use(URLFormat)
+
+	r.NotFound(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		w.Write([]byte("nothing here"))
+	})
+
+	r.Route("/samples/articles/samples.{articleID}", func(r chi.Router) {
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			articleID := chi.URLParam(r, "articleID")
+			w.Write([]byte(articleID))
+		})
+	})
+
+	r.Route("/articles/{articleID}", func(r chi.Router) {
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			articleID := chi.URLParam(r, "articleID")
+			w.Write([]byte(articleID))
+		})
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	if _, resp := testRequest(t, ts, "GET", "/articles/1.json", nil); resp != "1" {
+		t.Fatalf(resp)
+	}
+	if _, resp := testRequest(t, ts, "GET", "/articles/1.xml", nil); resp != "1" {
+		t.Fatalf(resp)
+	}
+	if _, resp := testRequest(t, ts, "GET", "/samples/articles/samples.1.json", nil); resp != "1" {
+		t.Fatalf(resp)
+	}
+	if _, resp := testRequest(t, ts, "GET", "/samples/articles/samples.1.xml", nil); resp != "1" {
+		t.Fatalf(resp)
+	}
+}

--- a/middleware/url_format_test.go
+++ b/middleware/url_format_test.go
@@ -1,10 +1,11 @@
 package middleware
 
 import (
-	"github.com/go-chi/chi"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/go-chi/chi"
 )
 
 func TestUrlFormat(t *testing.T) {


### PR DESCRIPTION
Chops the Suffix rather than the Prefix of the end item of the route so the behavior matches how the middleware is described inside middleware's comments.
See Issue https://github.com/go-chi/chi/issues/530