### PR TITLE
Make StripSlashes middleware work with other routers

### DIFF
--- a/middleware/strip.go
+++ b/middleware/strip.go
@@ -14,13 +14,18 @@ func StripSlashes(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		var path string
 		rctx := chi.RouteContext(r.Context())
-		if rctx.RoutePath != "" {
+		if rctx != nil && rctx.RoutePath != "" {
 			path = rctx.RoutePath
 		} else {
 			path = r.URL.Path
 		}
 		if len(path) > 1 && path[len(path)-1] == '/' {
-			rctx.RoutePath = path[:len(path)-1]
+			newPath := path[:len(path)-1]
+			if rctx == nil {
+				r.URL.Path = newPath
+			} else {
+				rctx.RoutePath = newPath
+			}
 		}
 		next.ServeHTTP(w, r)
 	}


### PR DESCRIPTION
Because StripSlashes specifically looks for the routeContext, it breaks when used with other routers since the route context will be nil

I added a few checks and conditionals for these situations