### PR TITLE
Be explicit about the need for the @v4 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ included some useful/optional subpackages: [middleware](/middleware), [render](h
 
 ## Install
 
-`go get -u github.com/go-chi/chi`
+`go get -u github.com/go-chi/chi@v4`
 
 
 ## Features


### PR DESCRIPTION
Be explicit about using v4.x tags. Addresses https://github.com/go-chi/chi/issues/462.