### PR TITLE
Add request logger only for 4xx and 5xx

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,28 +331,29 @@ with `net/http` can be used with chi's mux.
 
 ### Core middlewares
 
-----------------------------------------------------------------------------------------------------
-| chi/middleware Handler | description                                                             |
-| :--------------------- | :---------------------------------------------------------------------- |
-| [AllowContentType]     | Explicit whitelist of accepted request Content-Types                    |
-| [BasicAuth]            | Basic HTTP authentication                                               |
-| [Compress]             | Gzip compression for clients that accept compressed responses           |
-| [GetHead]              | Automatically route undefined HEAD requests to GET handlers             |
-| [Heartbeat]            | Monitoring endpoint to check the servers pulse                          |
-| [Logger]               | Logs the start and end of each request with the elapsed processing time |
-| [NoCache]              | Sets response headers to prevent clients from caching                   |
-| [Profiler]             | Easily attach net/http/pprof to your routers                            |
-| [RealIP]               | Sets a http.Request's RemoteAddr to either X-Forwarded-For or X-Real-IP |
-| [Recoverer]            | Gracefully absorb panics and prints the stack trace                     |
-| [RequestID]            | Injects a request ID into the context of each request                   |
-| [RedirectSlashes]      | Redirect slashes on routing paths                                       |
-| [SetHeader]            | Short-hand middleware to set a response header key/value                |
-| [StripSlashes]         | Strip slashes on routing paths                                          |
-| [Throttle]             | Puts a ceiling on the number of concurrent requests                     |
-| [Timeout]              | Signals to the request context when the timeout deadline is reached     |
-| [URLFormat]            | Parse extension from url and put it on request context                  |
-| [WithValue]            | Short-hand middleware to set a key/value on the request context         |
-----------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------------------------------
+| chi/middleware Handler | description                                                                                                         |
+| :--------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| [AllowContentType]     | Explicit whitelist of accepted request Content-Types                                                                |
+| [BasicAuth]            | Basic HTTP authentication                                                                                           |
+| [Compress]             | Gzip compression for clients that accept compressed responses                                                       |
+| [GetHead]              | Automatically route undefined HEAD requests to GET handlers                                                         |
+| [Heartbeat]            | Monitoring endpoint to check the servers pulse                                                                      |
+| [Logger]               | Logs the start and end of each request with the elapsed processing time                                             |
+| [Logger4xxAnd5xx]      | Logs the start and end of each request with the elapsed processing time (only for http status 4xx and 5xx response) |
+| [NoCache]              | Sets response headers to prevent clients from caching                                                               |
+| [Profiler]             | Easily attach net/http/pprof to your routers                                                                        |
+| [RealIP]               | Sets a http.Request's RemoteAddr to either X-Forwarded-For or X-Real-IP                                             |
+| [Recoverer]            | Gracefully absorb panics and prints the stack trace                                                                 |
+| [RequestID]            | Injects a request ID into the context of each request                                                               |
+| [RedirectSlashes]      | Redirect slashes on routing paths                                                                                   |
+| [SetHeader]            | Short-hand middleware to set a response header key/value                                                            |
+| [StripSlashes]         | Strip slashes on routing paths                                                                                      |
+| [Throttle]             | Puts a ceiling on the number of concurrent requests                                                                 |
+| [Timeout]              | Signals to the request context when the timeout deadline is reached                                                 |
+| [URLFormat]            | Parse extension from url and put it on request context                                                              |
+| [WithValue]            | Short-hand middleware to set a key/value on the request context                                                     |
+------------------------------------------------------------------------------------------------------------------------------------------------
 
 [AllowContentEncoding]: https://pkg.go.dev/github.com/go-chi/chi/middleware#AllowContentEncoding
 [AllowContentType]: https://pkg.go.dev/github.com/go-chi/chi/middleware#AllowContentType
@@ -363,6 +364,7 @@ with `net/http` can be used with chi's mux.
 [GetReqID]: https://pkg.go.dev/github.com/go-chi/chi/middleware#GetReqID
 [Heartbeat]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Heartbeat
 [Logger]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Logger
+[Logger4xxAnd5xx]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Logger4xxAnd5xx
 [New]: https://pkg.go.dev/github.com/go-chi/chi/middleware#New
 [NextRequestID]: https://pkg.go.dev/github.com/go-chi/chi/middleware#NextRequestID
 [NoCache]: https://pkg.go.dev/github.com/go-chi/chi/middleware#NoCache

--- a/_examples/logging-4xx-5xx/main.go
+++ b/_examples/logging-4xx-5xx/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+)
+
+// Response defines response object
+type Response struct {
+	Message string `json:"message"`
+}
+
+func main() {
+	flag.Parse()
+
+	r := chi.NewRouter()
+
+	r.Use(middleware.RequestID)
+	r.Use(middleware.Logger4xxAnd5xx)
+	r.Use(middleware.Recoverer)
+
+	r.Get("/", testOK)
+	r.Get("/log-4xx", test4xx)
+	r.Get("/log-5xx", test5xx)
+
+	http.ListenAndServe(":3333", r)
+}
+
+func testOK(w http.ResponseWriter, r *http.Request) {
+	resp := Response{Message: "success"}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
+}
+
+func test4xx(w http.ResponseWriter, r *http.Request) {
+	resp := Response{Message: "bad request"}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	json.NewEncoder(w).Encode(resp)
+}
+
+func test5xx(w http.ResponseWriter, r *http.Request) {
+	resp := Response{Message: "server error"}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	json.NewEncoder(w).Encode(resp)
+}


### PR DESCRIPTION
## What I do?

- Add one more request logger to only log request for  http status 4xx/5xx response `Logger4xxAnd5xx`

# Reason why I do this

Currently middleware `Logger` will log every request whether it's 2xx, 3xx, 4xx, and 5xx.  Sometimes we only need to log for unsuccessful request. That's why I propose this middleware.

In my project, logs are filled by http 200 request which most of them are health check (I run my project on kubernetes, so I need to provide health check endpoint). It's so painful to see my log full of unnecessary log like this. It makes me hard to find/see if error happened.

<img width="1341" alt="Screen Shot 2020-10-01 at 21 44 50" src="https://user-images.githubusercontent.com/9508513/94825663-9e8e4f80-0430-11eb-8033-8c01e4891c85.png">
