### PR TITLE
Make README godoc link more useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Copyright (c) 2015-present [Peter Kieltyka](https://github.com/pkieltyka)
 
 Licensed under [MIT License](./LICENSE)
 
-[GoDoc]: https://pkg.go.dev/github.com/go-chi/chi
+[GoDoc]: https://pkg.go.dev/github.com/go-chi/chi?tab=versions
 [GoDoc Widget]: https://godoc.org/github.com/go-chi/chi?status.svg
 [Travis]: https://travis-ci.org/go-chi/chi
 [Travis Widget]: https://travis-ci.org/go-chi/chi.svg?branch=master


### PR DESCRIPTION
I was initially confused by difference between what I was seeing in the documentation versus using Chi, until I realized I was looking at 4 year old docs. Sadly, the new pkg.go.dev server doesn't make it easy to see the correct version.

As far as I can tell, there isn't a perfect solution here. The pragmatic solution seems to be to ask the reader to pick the version they want to see.