### PR TITLE
use ConstantTimeCompare for password comparison

### DIFF
--- a/middleware/basic_auth.go
+++ b/middleware/basic_auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"net/http"
 )
@@ -16,7 +17,7 @@ func BasicAuth(realm string, creds map[string]string) func(next http.Handler) ht
 			}
 
 			credPass, credUserOk := creds[user]
-			if !credUserOk || pass != credPass {
+			if !credUserOk || subtle.ConstantTimeCompare([]byte(pass), []byte(credPass)) != 1 {
 				basicAuthFailed(w, realm)
 				return
 			}


### PR DESCRIPTION
Using constant time comparison for the password to prevent timing attacks.