### PR TITLE
logger: unwrap to return original responseWriter

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -43,7 +43,7 @@ func RequestLogger(f LogFormatter) func(next http.Handler) http.Handler {
 				entry.Write(ww.Status(), ww.BytesWritten(), ww.Header(), time.Since(t1), nil)
 			}()
 
-			next.ServeHTTP(ww, WithLogEntry(r, entry))
+			next.ServeHTTP(ww.Unwrap(), WithLogEntry(r, entry))
 		}
 		return http.HandlerFunc(fn)
 	}

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testLoggerWriter struct {
+	*httptest.ResponseRecorder
+}
+
+func (cw testLoggerWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, nil
+}
+
+func TestRequestLogger(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, ok := w.(http.Hijacker)
+		if !ok {
+			t.Errorf("http.Hijacker is unavailable on the writer. Unwrap it")
+		}
+	})
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := testLoggerWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+	}
+
+	handler := DefaultLogger(testHandler)
+	handler.ServeHTTP(w, r)
+}


### PR DESCRIPTION
currently the logger middleware returns a WrapResponseWriter which does not support the http.Hijacker interface.

Calling `Unwrap()` on the WrapResponseWriter, when passed to the handler will work.

This is necessary, because i cannot upgrade to websocket without the hijacker interface. I am using https://github.com/gorilla/websocket to upgrade.