### PR TITLE
logger: support websocket upgrade

### DIFF
--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type testLoggerWriter struct {
+	*httptest.ResponseRecorder
+}
+
+func (cw testLoggerWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, nil
+}
+
+func TestRequestLogger(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, ok := w.(http.Hijacker)
+		if !ok {
+			t.Errorf("http.Hijacker is unavailable on the writer. add the interface methods.")
+		}
+	})
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := testLoggerWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+	}
+
+	handler := DefaultLogger(testHandler)
+	handler.ServeHTTP(w, r)
+}

--- a/middleware/wrap_writer_test.go
+++ b/middleware/wrap_writer_test.go
@@ -5,15 +5,6 @@ import (
 	"testing"
 )
 
-func TestFlushWriterRemembersWroteHeaderWhenFlushed(t *testing.T) {
-	f := &flushWriter{basicWriter{ResponseWriter: httptest.NewRecorder()}}
-	f.Flush()
-
-	if !f.wroteHeader {
-		t.Fatal("want Flush to have set wroteHeader=true")
-	}
-}
-
 func TestHttpFancyWriterRemembersWroteHeaderWhenFlushed(t *testing.T) {
 	f := &httpFancyWriter{basicWriter{ResponseWriter: httptest.NewRecorder()}}
 	f.Flush()


### PR DESCRIPTION
currently the logger middleware returns a WrapResponseWriter which does not support the http.Hijacker interface.

These changes are necessary, because i cannot upgrade to websocket without the hijacker interface. I am using https://github.com/gorilla/websocket to upgrade.

see #559 for previous pull request