### PR TITLE
Ability to specify response HTTP status code for Throttle middleware

### DIFF
--- a/middleware/throttle.go
+++ b/middleware/throttle.go
@@ -22,6 +22,7 @@ type ThrottleOpts struct {
 	Limit          int
 	BacklogLimit   int
 	BacklogTimeout time.Duration
+	StatusCode     int
 }
 
 // Throttle is a middleware that limits number of currently processed requests
@@ -49,10 +50,16 @@ func ThrottleWithOpts(opts ThrottleOpts) func(http.Handler) http.Handler {
 		panic("chi/middleware: Throttle expects backlogLimit to be positive")
 	}
 
+	statusCode := opts.StatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusTooManyRequests
+	}
+
 	t := throttler{
 		tokens:         make(chan token, opts.Limit),
 		backlogTokens:  make(chan token, opts.Limit+opts.BacklogLimit),
 		backlogTimeout: opts.BacklogTimeout,
+		statusCode:     statusCode,
 		retryAfterFn:   opts.RetryAfterFn,
 	}
 
@@ -72,7 +79,7 @@ func ThrottleWithOpts(opts ThrottleOpts) func(http.Handler) http.Handler {
 
 			case <-ctx.Done():
 				t.setRetryAfterHeaderIfNeeded(w, true)
-				http.Error(w, errContextCanceled, http.StatusTooManyRequests)
+				http.Error(w, errContextCanceled, t.statusCode)
 				return
 
 			case btok := <-t.backlogTokens:
@@ -85,12 +92,12 @@ func ThrottleWithOpts(opts ThrottleOpts) func(http.Handler) http.Handler {
 				select {
 				case <-timer.C:
 					t.setRetryAfterHeaderIfNeeded(w, false)
-					http.Error(w, errTimedOut, http.StatusTooManyRequests)
+					http.Error(w, errTimedOut, t.statusCode)
 					return
 				case <-ctx.Done():
 					timer.Stop()
 					t.setRetryAfterHeaderIfNeeded(w, true)
-					http.Error(w, errContextCanceled, http.StatusTooManyRequests)
+					http.Error(w, errContextCanceled, t.statusCode)
 					return
 				case tok := <-t.tokens:
 					defer func() {
@@ -103,7 +110,7 @@ func ThrottleWithOpts(opts ThrottleOpts) func(http.Handler) http.Handler {
 
 			default:
 				t.setRetryAfterHeaderIfNeeded(w, false)
-				http.Error(w, errCapacityExceeded, http.StatusTooManyRequests)
+				http.Error(w, errCapacityExceeded, t.statusCode)
 				return
 			}
 		}
@@ -119,8 +126,9 @@ type token struct{}
 type throttler struct {
 	tokens         chan token
 	backlogTokens  chan token
-	retryAfterFn   func(ctxDone bool) time.Duration
 	backlogTimeout time.Duration
+	statusCode     int
+	retryAfterFn   func(ctxDone bool) time.Duration
 }
 
 // setRetryAfterHeaderIfNeeded sets Retry-After HTTP header if corresponding retryAfterFn option of throttler is initialized.

--- a/middleware/throttle.go
+++ b/middleware/throttle.go
@@ -26,7 +26,7 @@ type ThrottleOpts struct {
 
 // Throttle is a middleware that limits number of currently processed requests
 // at a time across all users. Note: Throttle is not a rate-limiter per user,
-// instead it just puts a ceiling on the number of currently in-flight requests
+// instead it just puts a ceiling on the number of current in-flight requests
 // being processed from the point from where the Throttle middleware is mounted.
 func Throttle(limit int) func(http.Handler) http.Handler {
 	return ThrottleWithOpts(ThrottleOpts{Limit: limit, BacklogTimeout: defaultBacklogTimeout})


### PR DESCRIPTION
Some time ago the PR [#528](https://github.com/go-chi/chi/pull/528) was merged but seems like in some cases 503 HTTP code is more suitable. Actually, using 503 or 429 response code for rate/conn limiting is a controversial topic. As for me, 429 HTTP code should be used when a **specific** client is breaking a contract by making too many requests over a certain period of time. It will be a bit strange if the client receives 429 on its first request.

P.S.:
- [Good post](http://blog.cellfish.se/2013/12/429-vs-503.html) about it.
- At Nginx 503 is used by default for [rate](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html#limit_req_status) and [conn](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_status) limiting.

This PR provides the ability to specify the needed status code. Could you please consider it?