### PR TITLE
Fixing RegisterMethod method value generation

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -6,7 +6,6 @@ package chi
 
 import (
 	"fmt"
-	"math"
 	"net/http"
 	"regexp"
 	"sort"
@@ -55,10 +54,10 @@ func RegisterMethod(method string) {
 		return
 	}
 	n := len(methodMap)
-	if n > strconv.IntSize {
+	if n > strconv.IntSize-1 {
 		panic(fmt.Sprintf("chi: max number of methods reached (%d)", strconv.IntSize))
 	}
-	mt := methodTyp(math.Exp2(float64(n)))
+	mt := methodTyp(2 << n)
 	methodMap[method] = mt
 	mALL |= mt
 }

--- a/tree.go
+++ b/tree.go
@@ -54,7 +54,7 @@ func RegisterMethod(method string) {
 		return
 	}
 	n := len(methodMap)
-	if n > strconv.IntSize-1 {
+	if n > strconv.IntSize-2 {
 		panic(fmt.Sprintf("chi: max number of methods reached (%d)", strconv.IntSize))
 	}
 	mt := methodTyp(2 << n)


### PR DESCRIPTION
- When registering the first New Method, de value generated was the same as mTRACE. So, some handler created to accept the "My new registered method" was accepting TRACE calls too.
- The "n" value must be lesser than IntSize - 2 to generate a fresh new value, otherwise returns 0.
- Changed code to use bit operations to generate the value
 