### PR TITLE
Fix data race in TestServerBaseContext

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -1683,10 +1683,11 @@ func TestServerBaseContext(t *testing.T) {
 
 	// Setup http Server with a base context
 	ctx := context.WithValue(context.Background(), ctxKey{"base"}, "yes")
-	ts := httptest.NewServer(r)
+	ts := httptest.NewUnstartedServer(r)
 	ts.Config.BaseContext = func(_ net.Listener) context.Context {
 		return ctx
 	}
+	ts.Start()
 
 	defer ts.Close()
 


### PR DESCRIPTION
Update the test server config before starting it, to fix data race in TestServerBaseContext:

```
$ go test -race
==================
WARNING: DATA RACE
Read at 0x00c00041c068 by goroutine 500:
  net/http.(*Server).Serve()
      /usr/lib/golang/src/net/http/server.go:2919 +0x325
  net/http/httptest.(*Server).goServe.func1()
      /usr/lib/golang/src/net/http/httptest/server.go:308 +0xd3

Previous write at 0x00c00041c068 by goroutine 1298:
  github.com/go-chi/chi.TestServerBaseContext()
      /home/rantala/git/chi/mux_test.go:1687 +0x202
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:1050 +0x1eb

Goroutine 500 (running) created at:
  net/http/httptest.(*Server).goServe()
      /usr/lib/golang/src/net/http/httptest/server.go:306 +0x69
  net/http/httptest.(*Server).Start()
      /usr/lib/golang/src/net/http/httptest/server.go:132 +0x15c
  net/http/httptest.NewServer()
      /usr/lib/golang/src/net/http/httptest/server.go:105 +0x1a2
  github.com/go-chi/chi.TestServerBaseContext()
      /home/rantala/git/chi/mux_test.go:1686 +0x144
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:1050 +0x1eb

Goroutine 1298 (running) created at:
  testing.(*T).Run()
      /usr/lib/golang/src/testing/testing.go:1095 +0x537
  testing.runTests.func1()
      /usr/lib/golang/src/testing/testing.go:1339 +0xa6
  testing.tRunner()
      /usr/lib/golang/src/testing/testing.go:1050 +0x1eb
  testing.runTests()
      /usr/lib/golang/src/testing/testing.go:1337 +0x594
  testing.(*M).Run()
      /usr/lib/golang/src/testing/testing.go:1252 +0x2ff
  main.main()
      _testmain.go:128 +0x223
==================
--- FAIL: TestServerBaseContext (0.00s)
    testing.go:965: race detected during execution of test
FAIL
```