### PR TITLE
Fix support for httptest.ResponseRecorder

### DIFF
--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -2,10 +2,12 @@ package middleware
 
 import (
 	"bufio"
+	"bytes"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 type testLoggerWriter struct {
@@ -31,4 +33,19 @@ func TestRequestLogger(t *testing.T) {
 
 	handler := DefaultLogger(testHandler)
 	handler.ServeHTTP(w, r)
+}
+
+func TestRequestLoggerReadFrom(t *testing.T) {
+	data := []byte("file data")
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeContent(w, r, "file", time.Time{}, bytes.NewReader(data))
+	})
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	handler := DefaultLogger(testHandler)
+	handler.ServeHTTP(w, r)
+
+	assertEqual(t, data, w.Body.Bytes())
 }

--- a/middleware/wrap_writer_test.go
+++ b/middleware/wrap_writer_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestHttpFancyWriterRemembersWroteHeaderWhenFlushed(t *testing.T) {
-	f := &httpFancyWriter{basicWriter{ResponseWriter: httptest.NewRecorder()}}
+	f := &httpFancyWriter{basicWriter: basicWriter{ResponseWriter: httptest.NewRecorder()}}
 	f.Flush()
 
 	if !f.wroteHeader {


### PR DESCRIPTION
If the `http.ResponseWriter` doesn't implement `io.ReaderFrom`, use a fallback implementation.

This fixes https://github.com/go-chi/chi/issues/583 without breaking the changes from https://github.com/go-chi/chi/pull/562.