### PR TITLE
Fix last set of missing v5 paths

### DIFF
--- a/_examples/versions/main.go
+++ b/_examples/versions/main.go
@@ -14,11 +14,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/_examples/versions/data"
-	v1 "github.com/go-chi/chi/_examples/versions/presenter/v1"
-	v2 "github.com/go-chi/chi/_examples/versions/presenter/v2"
-	v3 "github.com/go-chi/chi/_examples/versions/presenter/v3"
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/_examples/versions/data"
+	v1 "github.com/go-chi/chi/v5/_examples/versions/presenter/v1"
+	v2 "github.com/go-chi/chi/v5/_examples/versions/presenter/v2"
+	v3 "github.com/go-chi/chi/v5/_examples/versions/presenter/v3"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 )

--- a/_examples/versions/presenter/v1/article.go
+++ b/_examples/versions/presenter/v1/article.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"net/http"
 
-	"github.com/go-chi/chi/_examples/versions/data"
+	"github.com/go-chi/chi/v5/_examples/versions/data"
 )
 
 // Article presented in API version 1.

--- a/_examples/versions/presenter/v2/article.go
+++ b/_examples/versions/presenter/v2/article.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-chi/chi/_examples/versions/data"
+	"github.com/go-chi/chi/v5/_examples/versions/data"
 )
 
 // Article presented in API version 2.

--- a/_examples/versions/presenter/v3/article.go
+++ b/_examples/versions/presenter/v3/article.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"net/http"
 
-	"github.com/go-chi/chi/_examples/versions/data"
+	"github.com/go-chi/chi/v5/_examples/versions/data"
 )
 
 // Article presented in API version 2.


### PR DESCRIPTION
This fixes the paths that were missed in https://github.com/go-chi/chi/issues/561#issuecomment-787403243.

These `_` prefixed folders are actually ignored by the Go tool when ran from an upper directory, so there's no imminent need. My comment was wrong, this is strictly for finishing the move.

Might be a good idea to add to the builder something that explicitly tries to build the files in `_examples`, to catch any errors.