### PR TITLE
optimize sructs with memory alignment / padding

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -45,7 +45,6 @@ func Compress(level int, types ...string) func(next http.Handler) http.Handler {
 
 // Compressor represents a set of encoding configurations.
 type Compressor struct {
-	level int // The compression level.
 	// The mapping of encoder names to encoder functions.
 	encoders map[string]EncoderFunc
 	// The mapping of pooled encoders to pools.
@@ -55,6 +54,7 @@ type Compressor struct {
 	allowedWildcards map[string]struct{}
 	// The list of encoders in order of decreasing precedence.
 	encodingPrecedence []string
+	level              int // The compression level.
 }
 
 // NewCompressor creates a new Compressor that will handle encoding responses.
@@ -271,9 +271,9 @@ type compressResponseWriter struct {
 	// The streaming encoder writer to be used if there is one. Otherwise,
 	// this is just the normal writer.
 	w                io.Writer
-	encoding         string
 	contentTypes     map[string]struct{}
 	contentWildcards map[string]struct{}
+	encoding         string
 	wroteHeader      bool
 	compressable     bool
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -53,8 +53,8 @@ func TestCompressor(t *testing.T) {
 	tests := []struct {
 		name              string
 		path              string
-		acceptedEncodings []string
 		expectedEncoding  string
+		acceptedEncodings []string
 	}{
 		{
 			name:              "no expected encodings due to no accepted encodings",
@@ -114,10 +114,10 @@ func TestCompressor(t *testing.T) {
 func TestCompressorWildcards(t *testing.T) {
 	tests := []struct {
 		name       string
+		recover    string
 		types      []string
 		typesCount int
 		wcCount    int
-		recover    string
 	}{
 		{
 			name:       "defaults",

--- a/middleware/route_headers.go
+++ b/middleware/route_headers.go
@@ -112,9 +112,9 @@ func (hr HeaderRouter) Handler(next http.Handler) http.Handler {
 }
 
 type HeaderRoute struct {
-	MatchAny   []Pattern
-	MatchOne   Pattern
 	Middleware func(next http.Handler) http.Handler
+	MatchOne   Pattern
+	MatchAny   []Pattern
 }
 
 func (r HeaderRoute) IsMatch(value string) bool {

--- a/mux.go
+++ b/mux.go
@@ -19,20 +19,19 @@ var _ Router = &Mux{}
 // particularly useful for writing large REST API services that break a handler
 // into many smaller parts composed of middlewares and end handlers.
 type Mux struct {
-	// The radix trie router
-	tree *node
-
-	// The middleware stack
-	middlewares []func(http.Handler) http.Handler
-
-	// Controls the behaviour of middleware chain generation when a mux
-	// is registered as an inline group inside another mux.
-	inline bool
-	parent *Mux
-
 	// The computed mux handler made of the chained middleware stack and
 	// the tree router
 	handler http.Handler
+
+	// The radix trie router
+	tree *node
+
+	// Custom method not allowed handler
+	methodNotAllowedHandler http.HandlerFunc
+
+	// Controls the behaviour of middleware chain generation when a mux
+	// is registered as an inline group inside another mux.
+	parent *Mux
 
 	// Routing context pool
 	pool *sync.Pool
@@ -40,8 +39,10 @@ type Mux struct {
 	// Custom route not found handler
 	notFoundHandler http.HandlerFunc
 
-	// Custom method not allowed handler
-	methodNotAllowedHandler http.HandlerFunc
+	// The middleware stack
+	middlewares []func(http.Handler) http.Handler
+
+	inline bool
 }
 
 // NewMux returns a newly initialized Mux object that implements the Router

--- a/mux_test.go
+++ b/mux_test.go
@@ -1219,11 +1219,11 @@ func TestServeHTTPExistingContext(t *testing.T) {
 	})
 
 	testcases := []struct {
+		Ctx            context.Context
 		Method         string
 		Path           string
-		Ctx            context.Context
-		ExpectedStatus int
 		ExpectedBody   string
+		ExpectedStatus int
 	}{
 		{
 			Method:         "GET",

--- a/tree.go
+++ b/tree.go
@@ -72,17 +72,9 @@ const (
 )
 
 type node struct {
-	// node type: static, regexp, param, catchAll
-	typ nodeTyp
 
-	// first byte of the prefix
-	label byte
-
-	// first byte of the child prefix
-	tail byte
-
-	// prefix is the common prefix we ignore
-	prefix string
+	// subroutes on the leaf node
+	subroutes Routes
 
 	// regexp matcher for regexp nodes
 	rex *regexp.Regexp
@@ -90,12 +82,21 @@ type node struct {
 	// HTTP handler endpoints on the leaf node
 	endpoints endpoints
 
-	// subroutes on the leaf node
-	subroutes Routes
+	// prefix is the common prefix we ignore
+	prefix string
 
 	// child nodes should be stored in-order for iteration,
 	// in groups of the node type.
 	children [ntCatchAll + 1]nodes
+
+	// first byte of the child prefix
+	tail byte
+
+	// node type: static, regexp, param, catchAll
+	typ nodeTyp
+
+	// first byte of the prefix
+	label byte
 }
 
 // endpoints is a mapping of http method constants to handlers

--- a/tree_test.go
+++ b/tree_test.go
@@ -202,11 +202,11 @@ func TestTreeMoar(t *testing.T) {
 	tr.InsertRoute(mGET, "/users/{id}/settings/*", hStub16)
 
 	tests := []struct {
-		m methodTyp    // input request http method
-		r string       // input request path
-		h http.Handler // output matched handler
-		k []string     // output param keys
-		v []string     // output param values
+		h http.Handler
+		r string
+		k []string
+		v []string
+		m methodTyp
 	}{
 		{m: mGET, r: "/articles/search", h: hStub1, k: []string{}, v: []string{}},
 		{m: mGET, r: "/articlefun", h: hStub5, k: []string{}, v: []string{}},
@@ -394,8 +394,8 @@ func TestTreeRegexMatchWholeParam(t *testing.T) {
 	tr.InsertRoute(mGET, "/{param:[0-9]*}/test", hStub1)
 
 	tests := []struct {
-		url             string
 		expectedHandler http.Handler
+		url             string
 	}{
 		{url: "/13", expectedHandler: hStub1},
 		{url: "/a13", expectedHandler: nil},


### PR DESCRIPTION
Another small optimizations on structs.

- middleware/compress.go :
  - struct with 48 pointer bytes could be 40
  - struct with 64 pointer bytes could be 56
- middleware/route_headers.go : struct with 72 pointer bytes could be 56
- mux.go : struct with 88 pointer bytes could be 64
- tree.go : struct with 136 pointer bytes could be 128
