### PR TITLE
Feat/add pprof handlers

### DIFF
--- a/middleware/profiler.go
+++ b/middleware/profiler.go
@@ -35,7 +35,13 @@ func Profiler() http.Handler {
 	r.HandleFunc("/pprof/symbol", pprof.Symbol)
 	r.HandleFunc("/pprof/trace", pprof.Trace)
 	r.HandleFunc("/vars", expVars)
+
 	r.Handle("/pprof/goroutine", pprof.Handler("goroutine"))
+	r.Handle("/pprof/threadcreate", pprof.Handler("threadcreate"))
+	r.Handle("/pprof/mutex", pprof.Handler("mutex"))
+	r.Handle("/pprof/heap", pprof.Handler("heap"))
+	r.Handle("/pprof/block", pprof.Handler("block"))
+	r.Handle("/pprof/allocs", pprof.Handler("allocs"))
 
 	return r
 }

--- a/middleware/profiler.go
+++ b/middleware/profiler.go
@@ -35,6 +35,7 @@ func Profiler() http.Handler {
 	r.HandleFunc("/pprof/symbol", pprof.Symbol)
 	r.HandleFunc("/pprof/trace", pprof.Trace)
 	r.HandleFunc("/vars", expVars)
+	r.Handle("/pprof/goroutine", pprof.Handler("goroutine"))
 
 	return r
 }


### PR DESCRIPTION
### ISSUE: 

ATM when activating profiler middleware we cannot navigate to specific profiles through the index page available under `/pprof`

### STEPS TO REPRODUCE:

1. Setup basic go server using chi as router
2. Register profiler middleware
3. Navigate to profiler debug index route
4. Click on `goroutine`, `heap` etc.. and you should be redirected to the same page

### FIX:

- [x] Add pprof handlers to profiler router