### PR TITLE
Correct docs regarding X-Real-IP/X-Forwarded-For precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ with `net/http` can be used with chi's mux.
 | [Logger]               | Logs the start and end of each request with the elapsed processing time |
 | [NoCache]              | Sets response headers to prevent clients from caching                   |
 | [Profiler]             | Easily attach net/http/pprof to your routers                            |
-| [RealIP]               | Sets a http.Request's RemoteAddr to either X-Forwarded-For or X-Real-IP |
+| [RealIP]               | Sets a http.Request's RemoteAddr to either X-Real-IP or X-Forwarded-For |
 | [Recoverer]            | Gracefully absorb panics and prints the stack trace                     |
 | [RequestID]            | Injects a request ID into the context of each request                   |
 | [RedirectSlashes]      | Redirect slashes on routing paths                                       |

--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -12,7 +12,7 @@ var xForwardedFor = http.CanonicalHeaderKey("X-Forwarded-For")
 var xRealIP = http.CanonicalHeaderKey("X-Real-IP")
 
 // RealIP is a middleware that sets a http.Request's RemoteAddr to the results
-// of parsing either the X-Forwarded-For header or the X-Real-IP header (in that
+// of parsing either the X-Real-IP header or the X-Forwarded-For header (in that
 // order).
 //
 // This middleware should be inserted fairly early in the middleware stack to

--- a/middleware/realip_test.go
+++ b/middleware/realip_test.go
@@ -55,3 +55,28 @@ func TestXForwardForIP(t *testing.T) {
 		t.Fatal("Test get real IP error.")
 	}
 }
+
+func TestXForwardForXRealIPPrecedence(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Add("X-Forwarded-For", "0.0.0.0")
+	req.Header.Add("X-Real-IP", "100.100.100.100")
+	w := httptest.NewRecorder()
+
+	r := chi.NewRouter()
+	r.Use(RealIP)
+
+	realIP := ""
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		realIP = r.RemoteAddr
+		w.Write([]byte("Hello World"))
+	})
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatal("Response Code should be 200")
+	}
+
+	if realIP != "100.100.100.100" {
+		t.Fatal("Test get real IP precedence error.")
+	}
+}


### PR DESCRIPTION
It's important to be clear about the order - as an example, AWS ALBs set X-Forwarded-For. If you as a developer assume the docs are correct, it may be possible for a user to spoof their IP address by setting an X-Real-IP header.

Added a test case demonstrating the precedence.

Some discussion here: https://github.com/go-chi/chi/issues/536#issuecomment-811615534