### PR TITLE
recoverer: don't recover http.ErrAbortHandler

### DIFF
--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -22,7 +22,12 @@ import (
 func Recoverer(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
-			if rvr := recover(); rvr != nil && rvr != http.ErrAbortHandler {
+			if rvr := recover(); rvr != nil {
+				if rvr == http.ErrAbortHandler {
+					// we don't recover http.ErrAbortHandler so the response
+					// to the client is aborted, this should not be logged
+					panic(rvr)
+				}
 
 				logEntry := GetLogEntry(r)
 				if logEntry != nil {

--- a/middleware/recoverer_test.go
+++ b/middleware/recoverer_test.go
@@ -40,3 +40,28 @@ func TestRecoverer(t *testing.T) {
 	}
 	t.Fatal("First func call line should start with ->.")
 }
+
+func TestRecovererAbortHandler(t *testing.T) {
+	defer func() {
+		rcv := recover()
+		if rcv != http.ErrAbortHandler {
+			t.Fatalf("http.ErrAbortHandler should not be recovered")
+		}
+	}()
+
+	w := httptest.NewRecorder()
+
+	r := chi.NewRouter()
+	r.Use(Recoverer)
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.ServeHTTP(w, req)
+}


### PR DESCRIPTION
This error is generally used to abort a request while streaming a response
so it should not be recovered otherwise the request is not aborted and
the client does not detect the error.

In my use case I'm streaming a zip file directly to the client (without writing it to the disk). If an error happen while streaming the request body I return `http.ErrAbortHandler` to abort the request without logging a panic. This is the only way to report an error to the client/browser. So this error should not be recovered otherwise the request is not aborted and the client does not detect the error.

My use case is quite similar to the one described [here](https://github.com/golang/go/issues/23643)