### PR TITLE
Allow regex url paths ending which includes slashes

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -423,6 +423,14 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 				// label for param nodes is the delimiter byte
 				p := strings.IndexByte(xsearch, xn.tail)
 
+				// For RegexP matches we allow full-path-matches if this is the last param
+				if ntyp == ntRegexp && xn.isLeaf() && xn.tail == '/' && xn.rex != nil {
+					loc := xn.rex.FindStringIndex(xsearch)
+					if loc != nil && loc[0] == 0 {
+						p = loc[1]
+					}
+				}
+
 				if p < 0 {
 					if xn.tail == '/' {
 						p = len(xsearch)

--- a/tree_test.go
+++ b/tree_test.go
@@ -275,8 +275,12 @@ func TestTreeRegexp(t *testing.T) {
 	hStub5 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	hStub6 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	hStub7 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	hStub8 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	hStub9 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
 	tr := &node{}
+	tr.InsertRoute(mGET, "/articles/{path:[a-z/]+}", hStub8)
+	tr.InsertRoute(mGET, "/articles/{path:[a-z/]+}.json", hStub9)
 	tr.InsertRoute(mGET, "/articles/{rid:^[0-9]{5,6}}", hStub7)
 	tr.InsertRoute(mGET, "/articles/{zid:^0[0-9]+}", hStub3)
 	tr.InsertRoute(mGET, "/articles/{name:^@[a-z]+}/posts", hStub4)
@@ -297,6 +301,8 @@ func TestTreeRegexp(t *testing.T) {
 		k []string     // output param keys
 		v []string     // output param values
 	}{
+		{r: "/articles/a/b/c", h: hStub8, k: []string{"path"}, v: []string{"a/b/c"}},
+		{r: "/articles/a/b/c.json", h: hStub9, k: []string{"path"}, v: []string{"a/b/c"}},
 		{r: "/articles", h: nil, k: []string{}, v: []string{}},
 		{r: "/articles/12345", h: hStub7, k: []string{"rid"}, v: []string{"12345"}},
 		{r: "/articles/123", h: hStub1, k: []string{"id"}, v: []string{"123"}},


### PR DESCRIPTION
This PR allows paths like (it makes the second one possible):

```go
r.Get("/v0/{path:[a-zA-Z0-9-/]+}.{format:(json|xml|html)+}", a.getTreeObject)
r.Get("/v0/{path:[a-zA-Z0-9-/]+}", a.getTreeObject)
```

witch matche URL's like:
```yaml
urls:
  -  /v0/lists/com/github/go-chi/chi/v5
  -  /v0/lists/com/github/go-chi/chi/v5.json
```

While this works for me (tm) and i ran the test cases, idk it's the right way.

Kind Regards,
René

Signed-off-by: René Jochum <rene@jochum.dev>