### PR TITLE
Fix middleware.Recoverer under Go 1.17+

### DIFF
--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -124,17 +124,18 @@ func (s prettyStack) decorateFuncCallLine(line string, useColor bool, num int) (
 	// addr := line[idx:]
 	method := ""
 
-	idx = strings.LastIndex(pkg, string(os.PathSeparator))
-	if idx < 0 {
-		idx = strings.Index(pkg, ".")
-		method = pkg[idx:]
-		pkg = pkg[0:idx]
+	if idx := strings.LastIndex(pkg, string(os.PathSeparator)); idx < 0 {
+		if idx := strings.Index(pkg, "."); idx > 0 {
+			method = pkg[idx:]
+			pkg = pkg[0:idx]
+		}
 	} else {
 		method = pkg[idx+1:]
 		pkg = pkg[0 : idx+1]
-		idx = strings.Index(method, ".")
-		pkg += method[0:idx]
-		method = method[idx:]
+		if idx := strings.Index(method, "."); idx > 0 {
+			pkg += method[0:idx]
+			method = method[idx:]
+		}
 	}
 	pkgColor := nYellow
 	methodColor := bGreen

--- a/middleware/recoverer_test.go
+++ b/middleware/recoverer_test.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestRecoverer(t *testing.T) {
+	r := chi.NewRouter()
+
+	r.Use(Recoverer)
+	r.Get("/", func(http.ResponseWriter, *http.Request) { panic("foo") })
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	res, _ := testRequest(t, ts, "GET", "/", nil)
+	assertEqual(t, res.StatusCode, http.StatusInternalServerError)
+}


### PR DESCRIPTION
Under Go 1.17+ the lines of the debug stack aren't guaranteed to contain a period, notability a line can just read "panic".

This commit adds some defensive programming to ensure we don't attempt to slice with a negative index and adds a very basic test to catch the negative index panic without this change.

For example, Go 1.16:
```
 panic: foo
 
 -> github.com/go-chi/chi/v5/middleware.TestRecoverer.func1
 ->   /home/jraspass/chi/middleware/recoverer_test.go:15

    net/http.HandlerFunc.ServeHTTP
      /usr/lib/go/src/net/http/server.go:2069
    github.com/go-chi/chi/v5.(*Mux).routeHTTP
      /home/jraspass/chi/mux.go:442
    net/http.HandlerFunc.ServeHTTP
      /usr/lib/go/src/net/http/server.go:2069
    github.com/go-chi/chi/v5/middleware.Recoverer.func1
      /home/jraspass/chi/middleware/recoverer.go:37
    net/http.HandlerFunc.ServeHTTP
      /usr/lib/go/src/net/http/server.go:2069
    github.com/go-chi/chi/v5.(*Mux).ServeHTTP
      /home/jraspass/chi/mux.go:88
    net/http.serverHandler.ServeHTTP
      /usr/lib/go/src/net/http/server.go:2887
    net/http.(*conn).serve
      /usr/lib/go/src/net/http/server.go:1952
    created by net/http.(*Server).Serve
      /usr/lib/go/src/net/http/server.go:3013
 ```
 
 Go 1.17beta1:
 ```
  panic: foo
 
 -> runtime/debug.Stack
 ->   /home/jraspass/sdk/go1.17beta1/src/runtime/debug/stack.go:24

    github.com/go-chi/chi/v5/middleware.PrintPrettyStack
      /home/jraspass/chi/middleware/recoverer.go:44
    github.com/go-chi/chi/v5/middleware.Recoverer.func1.1
      /home/jraspass/chi/middleware/recoverer.go:30
    panic
      /home/jraspass/sdk/go1.17beta1/src/runtime/panic.go:1038
    github.com/go-chi/chi/v5/middleware.TestRecoverer.func1
      /home/jraspass/chi/middleware/recoverer_test.go:15
    net/http.HandlerFunc.ServeHTTP
      /home/jraspass/sdk/go1.17beta1/src/net/http/server.go:2046
    github.com/go-chi/chi/v5.(*Mux).routeHTTP
      /home/jraspass/chi/mux.go:442
    net/http.HandlerFunc.ServeHTTP
      /home/jraspass/sdk/go1.17beta1/src/net/http/server.go:2046
    github.com/go-chi/chi/v5/middleware.Recoverer.func1
      /home/jraspass/chi/middleware/recoverer.go:37
    net/http.HandlerFunc.ServeHTTP
      /home/jraspass/sdk/go1.17beta1/src/net/http/server.go:2046
    github.com/go-chi/chi/v5.(*Mux).ServeHTTP
      /home/jraspass/chi/mux.go:88
    net/http.serverHandler.ServeHTTP
      /home/jraspass/sdk/go1.17beta1/src/net/http/server.go:2878
    net/http.(*conn).serve
      /home/jraspass/sdk/go1.17beta1/src/net/http/server.go:1929
    created by net/http.(*Server).Serve
      /home/jraspass/sdk/go1.17beta1/src/net/http/server.go:3033
```
Note the raw `panic` line with no periods.