### PR TITLE
middleware: fix set Vary header

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -318,7 +318,7 @@ func (cw *compressResponseWriter) WriteHeader(code int) {
 	if cw.encoding != "" {
 		cw.compressable = true
 		cw.Header().Set("Content-Encoding", cw.encoding)
-		cw.Header().Set("Vary", "Accept-Encoding")
+		cw.Header().Add("Vary", "Accept-Encoding")
 
 		// The content-length after compression is unknown
 		cw.Header().Del("Content-Length")


### PR DESCRIPTION
There are cases where you want to define a value(ex. origin, accept ...) other than accept-encoding in the Vary header.
So, if the Vary header is already set, why not give priority to the existing settings?