### PR TITLE
Fix middleware.Recoverer under Go 1.17+ (again)

### DIFF
--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"runtime/debug"
@@ -40,12 +41,14 @@ func Recoverer(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
+var recovererErrorWriter io.Writer = os.Stderr
+
 func PrintPrettyStack(rvr interface{}) {
 	debugStack := debug.Stack()
 	s := prettyStack{}
 	out, err := s.parse(debugStack, rvr)
 	if err == nil {
-		os.Stderr.Write(out)
+		recovererErrorWriter.Write(out)
 	} else {
 		// print stdlib output as a fallback
 		os.Stderr.Write(debugStack)

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -75,7 +75,7 @@ func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
 	// locate panic line, as we may have nested panics
 	for i := len(stack) - 1; i > 0; i-- {
 		lines = append(lines, stack[i])
-		if strings.HasPrefix(stack[i], "panic(0x") {
+		if strings.HasPrefix(stack[i], "panic(") {
 			lines = lines[0 : len(lines)-2] // remove boilerplate
 			break
 		}

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -41,6 +41,7 @@ func Recoverer(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
+// for ability to test the PrintPrettyStack function
 var recovererErrorWriter io.Writer = os.Stderr
 
 func PrintPrettyStack(rvr interface{}) {

--- a/middleware/recoverer_test.go
+++ b/middleware/recoverer_test.go
@@ -1,22 +1,42 @@
 package middleware
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 )
 
+func panicingHandler(http.ResponseWriter, *http.Request) { panic("foo") }
+
 func TestRecoverer(t *testing.T) {
 	r := chi.NewRouter()
 
+	oldRecovererErrorWriter := recovererErrorWriter
+	defer func() { recovererErrorWriter = oldRecovererErrorWriter }()
+	buf := &bytes.Buffer{}
+	recovererErrorWriter = buf
+
 	r.Use(Recoverer)
-	r.Get("/", func(http.ResponseWriter, *http.Request) { panic("foo") })
+	r.Get("/", panicingHandler)
 
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
 	res, _ := testRequest(t, ts, "GET", "/", nil)
 	assertEqual(t, res.StatusCode, http.StatusInternalServerError)
+
+	lines := strings.Split(buf.String(), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "->") {
+			if !strings.Contains(line, "panicingHandler") {
+				t.Fatalf("First func call line should refer to panicingHandler, but actual line:\n%v\n", line)
+			}
+			return
+		}
+	}
+	t.Fatal("First func call line should start with ->.")
 }


### PR DESCRIPTION
In Go 1.17 the format of the `debug.Stack()` was changed. In Go 1.16 we could see the following fragment:
```console
panic(0x67b480, 0x72a100)
``` 
But in Go 1.17 we have:
```console
panic({0x6d8bc0, 0x796560})
```
I.e. now there are curly brackets.

How does this show up while using `middleware.Recoverer`? With Go 1.16 I used to see something like:

![image](https://user-images.githubusercontent.com/71576382/131350266-4a2c08ff-d394-4ed0-a059-f60f8dd846f3.png)

But now with Go 1.17 I see:

![image](https://user-images.githubusercontent.com/71576382/131350364-f44bae2f-621e-47b7-a080-d47f3f2c3286.png)
I.e. now I see the internals.

How does this pull request fix that? By replacing the code fragment `strings.HasPrefix(stack[i], "panic(0x")` with `strings.HasPrefix(stack[i], "panic(")`.