### PR TITLE
add tests to match emails in simple patterns

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -1694,7 +1694,7 @@ func TestMuxMatch(t *testing.T) {
 	}
 
 	tctx.Reset()
-	if r.Match(tctx, "GET", "/users/john.doe@example.com") == false {
+	if r.Match(tctx, "GET", "/users/john.doe%40example.com") == false {
 		t.Fatal("expecting to find match for route:", "GET", "/users/john.doe%40example.com")
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -1689,6 +1689,16 @@ func TestMuxMatch(t *testing.T) {
 	}
 
 	tctx.Reset()
+	if r.Match(tctx, "GET", "/users/john.doe@example.com") == false {
+		t.Fatal("expecting to find match for route:", "GET", "/users/john.doe@example.com")
+	}
+
+	tctx.Reset()
+	if r.Match(tctx, "GET", "/users/john.doe@example.com") == false {
+		t.Fatal("expecting to find match for route:", "GET", "/users/john.doe%40example.com")
+	}
+
+	tctx.Reset()
 	if r.Match(tctx, "HEAD", "/articles/10") == true {
 		t.Fatal("not expecting to find match for route:", "HEAD", "/articles/10")
 	}


### PR DESCRIPTION
I was expecting to be able to match percent encoded URL parameters, e.g. in email adresses. The percent encoded URL is not matched however. I know I can change the pattern, but is that expected?