### PR TITLE
refactor/some lint

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -161,15 +161,13 @@ func (c *Compressor) SetEncoder(encoding string, fn EncoderFunc) {
 
 	// If the encoder supports Resetting (IoReseterWriter), then it can be pooled.
 	encoder := fn(ioutil.Discard, c.level)
-	if encoder != nil {
-		if _, ok := encoder.(ioResetterWriter); ok {
-			pool := &sync.Pool{
-				New: func() interface{} {
-					return fn(ioutil.Discard, c.level)
-				},
-			}
-			c.pooledEncoders[encoding] = pool
+	if _, ok := encoder.(ioResetterWriter); ok {
+		pool := &sync.Pool{
+			New: func() interface{} {
+				return fn(ioutil.Discard, c.level)
+			},
 		}
+		c.pooledEncoders[encoding] = pool
 	}
 	// If the encoder is not in the pooledEncoders, add it to the normal encoders.
 	if _, ok := c.pooledEncoders[encoding]; !ok {

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -156,12 +156,8 @@ func (c *Compressor) SetEncoder(encoding string, fn EncoderFunc) {
 
 	// If we are adding a new encoder that is already registered, we have to
 	// clear that one out first.
-	if _, ok := c.pooledEncoders[encoding]; ok {
-		delete(c.pooledEncoders, encoding)
-	}
-	if _, ok := c.encoders[encoding]; ok {
-		delete(c.encoders, encoding)
-	}
+	delete(c.pooledEncoders, encoding)
+	delete(c.encoders, encoding)
 
 	// If the encoder supports Resetting (IoReseterWriter), then it can be pooled.
 	encoder := fn(ioutil.Discard, c.level)

--- a/middleware/strip.go
+++ b/middleware/strip.go
@@ -53,7 +53,7 @@ func RedirectSlashes(next http.Handler) http.Handler {
 				path = path[:len(path)-1]
 			}
 			redirectURL := fmt.Sprintf("//%s%s", r.Host, path)
-			http.Redirect(w, r, redirectURL, 301)
+			http.Redirect(w, r, redirectURL, http.StatusMovedPermanently)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/tree.go
+++ b/tree.go
@@ -848,7 +848,7 @@ func walk(r Routes, walkFn WalkFunc, parentRoute string, parentMw ...func(http.H
 			}
 
 			fullRoute := parentRoute + route.Pattern
-			fullRoute = strings.Replace(fullRoute, "/*/", "/", -1)
+			fullRoute = strings.ReplaceAll(fullRoute, "/*/", "/")
 
 			if chain, ok := handler.(*ChainHandler); ok {
 				if err := walkFn(method, fullRoute, chain.Endpoint, append(mws, chain.Middlewares...)...); err != nil {


### PR DESCRIPTION
- Using strings.ReplaceAll when makes sense
- Do not need to check if a element exists before delete it
- Omit redundant nil check in type assertion
- Use http.StatusMovedPermanently instead of the 301 constant
