### PR TITLE
add net.ParseIP() as validation to RealIP middleware

### DIFF
--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -4,6 +4,7 @@ package middleware
 // https://github.com/zenazn/goji/tree/master/web/middleware
 
 import (
+	"net"
 	"net/http"
 	"strings"
 )
@@ -49,6 +50,8 @@ func realIP(r *http.Request) string {
 		}
 		ip = xff[:i]
 	}
-
+	if net.ParseIP(ip) == nil {
+		return ""
+	}
 	return ip
 }

--- a/middleware/realip_test.go
+++ b/middleware/realip_test.go
@@ -80,3 +80,27 @@ func TestXForwardForXRealIPPrecedence(t *testing.T) {
 		t.Fatal("Test get real IP precedence error.")
 	}
 }
+
+func TestIvalidIP(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Add("X-Real-IP", "100.100.100.1000")
+	w := httptest.NewRecorder()
+
+	r := chi.NewRouter()
+	r.Use(RealIP)
+
+	realIP := ""
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		realIP = r.RemoteAddr
+		w.Write([]byte("Hello World"))
+	})
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatal("Response Code should be 200")
+	}
+
+	if realIP != "" {
+		t.Fatal("Invalid IP used.")
+	}
+}


### PR DESCRIPTION
Added `net.ParseIP()` as simple validation on **RealIP** middleware. Fixed issue #664.