### PR TITLE
support ip chain without spaces in xForwarded header

### DIFF
--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -46,7 +46,7 @@ func realIP(r *http.Request) string {
 	} else if xrip := r.Header.Get(xRealIP); xrip != "" {
 		ip = xrip
 	} else if xff := r.Header.Get(xForwardedFor); xff != "" {
-		i := strings.Index(xff, ", ")
+		i := strings.Index(xff, ",")
 		if i == -1 {
 			i = len(xff)
 		}

--- a/middleware/realip_test.go
+++ b/middleware/realip_test.go
@@ -33,26 +33,35 @@ func TestXRealIP(t *testing.T) {
 }
 
 func TestXForwardForIP(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/", nil)
-	req.Header.Add("X-Forwarded-For", "100.100.100.100")
-	w := httptest.NewRecorder()
+	xForwardedForIPs := []string{
+		"100.100.100.100",
+		"100.100.100.100, 200.200.200.200",
+		"100.100.100.100,200.200.200.200",
+	}
 
 	r := chi.NewRouter()
 	r.Use(RealIP)
 
-	realIP := ""
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		realIP = r.RemoteAddr
-		w.Write([]byte("Hello World"))
-	})
-	r.ServeHTTP(w, req)
+	for _, v := range xForwardedForIPs {
+		req, _ := http.NewRequest("GET", "/", nil)
+		req.Header.Add("X-Forwarded-For", v)
 
-	if w.Code != 200 {
-		t.Fatal("Response Code should be 200")
-	}
+		w := httptest.NewRecorder()
 
-	if realIP != "100.100.100.100" {
-		t.Fatal("Test get real IP error.")
+		realIP := ""
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			realIP = r.RemoteAddr
+			w.Write([]byte("Hello World"))
+		})
+		r.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatal("Response Code should be 200")
+		}
+
+		if realIP != "100.100.100.100" {
+			t.Fatal("Test get real IP error.")
+		}
 	}
 }
 


### PR DESCRIPTION
This change covers a use case in `RealIP` middleware, when the chained IPs in `X-Forwarded-For` header are without space after comma.
This change is backwards compatible.
Test updated to cover this use case as well.