### PR TITLE
test(middleware): Improves test coverage

### DIFF
--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+)
+
+var testAuthCreds = map[string]string{
+	"testUser": "testPassword",
+}
+
+func TestBasicAuth(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(BasicAuth("localhost", testAuthCreds))
+	r.Get("/secure", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("authentication accepted"))
+	}))
+
+	cases := []struct {
+		name         string
+		digest       string
+		expected     int
+		errorMessage string
+		wantErr      bool
+	}{
+		{
+			name:         "No auth header provided",
+			expected:     http.StatusUnauthorized,
+			errorMessage: "basic auth: accepted request without a valid header",
+			wantErr:      true,
+		},
+		{
+			name:         "Invalid auth header provided",
+			digest:       "Basic dGVzdFVzZXI6d3JvbmdwYXNzd29yZA==",
+			expected:     http.StatusUnauthorized,
+			errorMessage: "basic auth: accepted invalid bearer token",
+			wantErr:      true,
+		},
+		{
+			name:         "Valid auth header provided",
+			digest:       "Basic dGVzdFVzZXI6dGVzdFBhc3N3b3Jk",
+			expected:     http.StatusOK,
+			errorMessage: "basic auth: did not accept a valid bearer token",
+			wantErr:      false,
+		},
+	}
+
+	for _, c := range cases {
+		// Record response
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/secure", nil)
+		if err != nil {
+			t.Fatalf("basic auth: failed to create test request")
+		}
+
+		if c.digest != "" {
+			req.Header.Set("Authorization", c.digest)
+		}
+
+		// Serve request
+		r.ServeHTTP(w, req)
+
+		// Test response code
+		if w.Result().StatusCode != c.expected {
+			t.Errorf(c.errorMessage)
+		}
+	}
+}

--- a/middleware/clean_path_test.go
+++ b/middleware/clean_path_test.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+)
+
+func TestCleanPath(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(CleanPath)
+	r.Get("/users/1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users////1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("clean path: unexpected response code: %v", w.Result().StatusCode)
+	}
+}

--- a/middleware/heartbeat_test.go
+++ b/middleware/heartbeat_test.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+)
+
+func TestHeartbeat(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Heartbeat("/ping"))
+	r.Get("/ping", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ping", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("heartbeat: unexpected response code: %v", w.Result().StatusCode)
+	}
+}

--- a/middleware/path_rewrite_test.go
+++ b/middleware/path_rewrite_test.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+)
+
+func TestPathRewrite(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(PathRewrite("/endpoint", "/v1/endpoint"))
+
+	r.Get("/v1/endpoint", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/endpoint", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("path rewrite: unexpected response code: %v", w.Result().StatusCode)
+	}
+}

--- a/middleware/terminal_test.go
+++ b/middleware/terminal_test.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"bytes"
+	"testing"
+)
+
+func Test_cW(t *testing.T) {
+	cases := []struct {
+		name     string
+		useColor bool
+		color    []byte
+		s        string
+		args     []interface{}
+		expected string
+	}{
+		{
+			name:     "No color",
+			useColor: false,
+			color:    nGreen,
+			s:        "no color test",
+			expected: "no color test",
+		},
+	}
+
+	for name, c := range cases {
+		actual := &bytes.Buffer{}
+		cW(actual, c.useColor, c.color, c.s, c.args...)
+
+		if actual.String() != c.expected {
+			t.Errorf("(case %q) unexpected output: got %q, expected: %q", name, actual.String(), c.expected)
+		}
+	}
+}

--- a/middleware/value_test.go
+++ b/middleware/value_test.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+)
+
+func TestWithValue(t *testing.T) {
+	ctxKey := "customKey"
+	ctxValue := "customValue"
+	request := func() *http.Request {
+		req, _ := http.NewRequest("GET", "/", nil)
+		return req
+	}
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		val := r.Context().Value(ctxKey).(string)
+		w.Write([]byte(val))
+	})
+
+	w := httptest.NewRecorder()
+	r := chi.NewRouter()
+	r.Use(WithValue(ctxKey, ctxValue))
+	r.Get("/", testHandler)
+
+	r.ServeHTTP(w, request())
+
+	if w.Body.String() != ctxValue {
+		t.Errorf("value: context did not contain expected value")
+	}
+}


### PR DESCRIPTION
This PR just aims to add some more code coverage for the middleware package. 

* Before

    `ok  	github.com/go-chi/chi/v5/middleware	25.464s	coverage: 61.0% of statements`

* After

    `ok  	github.com/go-chi/chi/v5/middleware	25.455s	coverage: 67.2% of statements`
