### PR TITLE
Use RoutePath in URLFormat middleware

### DIFF
--- a/middleware/url_format.go
+++ b/middleware/url_format.go
@@ -51,6 +51,11 @@ func URLFormat(next http.Handler) http.Handler {
 		var format string
 		path := r.URL.Path
 
+		rctx := chi.RouteContext(r.Context())
+		if rctx != nil && rctx.RoutePath != "" {
+			path = rctx.RoutePath
+		}
+
 		if strings.Index(path, ".") > 0 {
 			base := strings.LastIndex(path, "/")
 			idx := strings.LastIndex(path[base:], ".")
@@ -59,7 +64,6 @@ func URLFormat(next http.Handler) http.Handler {
 				idx += base
 				format = path[idx+1:]
 
-				rctx := chi.RouteContext(r.Context())
 				rctx.RoutePath = path[:idx]
 			}
 		}

--- a/middleware/url_format_test.go
+++ b/middleware/url_format_test.go
@@ -48,3 +48,22 @@ func TestURLFormat(t *testing.T) {
 		t.Fatalf(resp)
 	}
 }
+
+func TestURLFormatInSubRouter(t *testing.T) {
+	r := chi.NewRouter()
+
+	r.Route("/articles/{articleID}", func(r chi.Router) {
+		r.Use(URLFormat)
+		r.Get("/subroute", func(w http.ResponseWriter, r *http.Request) {
+			articleID := chi.URLParam(r, "articleID")
+			w.Write([]byte(articleID))
+		})
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	if _, resp := testRequest(t, ts, "GET", "/articles/1/subroute.json", nil); resp != "1" {
+		t.Fatalf(resp)
+	}
+}


### PR DESCRIPTION
Currently the URLFormat middleware is resetting the RoutePath to the full URL when used in a sub-router. This change makes it look at the RoutePath, if it exists, and uses that instead of the full URL.