### PR TITLE
Add a check to prevent modifying outer scope routers

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -1449,6 +1449,36 @@ func TestMuxWildcardRouteCheckTwo(t *testing.T) {
 	r.Get("/*/wildcard/{must}/be/at/end", handler)
 }
 
+func TestMuxGuardOuterGroup(t *testing.T) {
+	mw := func(next http.Handler) http.Handler { return next }
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic()")
+		}
+	}()
+
+	outer := NewRouter()
+	outer.Group(func(inner Router) {
+		outer.Use(mw)
+	})
+}
+
+func TestMuxGuardOuterRoute(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic()")
+		}
+	}()
+
+	outer := NewRouter()
+	outer.Route("/foo", func(inner Router) {
+		outer.Get("/bar", handler)
+	})
+}
+
 func TestMuxRegexp(t *testing.T) {
 	r := NewRouter()
 	r.Route("/{param:[0-9]*}/test", func(r Router) {


### PR DESCRIPTION
This patch adds a panic that triggers when the build function passed to
(*Mux).Route() or (*Mux).Group() attempts to set routes or middleware on a
router is a parent of its argument router.

Example:

```
root := chi.NewRouter()
root.Route("/api", func(api chi.Router) {
    root.Use(DatabaseTransaction)
    // ...
})
root.Get("/health-check", HealthCheck)
```

This reads as if the DatabaseTransaction was intended to be used as middleware
on the api sub-router but it is actually used on the top-level router, making
it run in the hot path of the /health-check handler.

Adding this check will catch such mistakes.