### PR TITLE
Added Bearer Token Authentication

### DIFF
--- a/middleware/bearer_token.go
+++ b/middleware/bearer_token.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// BearerToken implements a simple middleware handler for adding bearer token auth to a route.
+func BearerToken(token string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			bearerToken := r.Header.Get("Authorization")
+
+			expected := fmt.Sprintf("Bearer %s", token)
+			if bearerToken != expected {
+				bearerTokenFailed(w)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func bearerTokenFailed(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusUnauthorized)
+}


### PR DESCRIPTION
Hey,

I've added a simple middleware analog to BasicAuth for a Bearer Token in the Authentication header.

This can be used like this:
```go
r.Use(middleware.BearerToken("testing123"))
// or
r.Get("/{filename}", handler.GetFile)
r.Head("/{filename}", handler.HeadFile)
r.With(middleware.BearerToken(Token())).Put("/{filename}", handler.PutFile)
r.With(middleware.BearerToken(Token())).Delete("/{filename}", handler.DeleteFile)
```

Currently only a single token can be passed. If it seems necessary or useful the method can be changed to accept multiple tokens.