### PR TITLE
Check for NO_COLOR in default logging middleware

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -166,7 +166,8 @@ func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
 }
 
 func init() {
-	color := true
+	_, noColor := os.LookupEnv("NO_COLOR")
+	color := !noColor
 	if runtime.GOOS == "windows" {
 		color = false
 	}


### PR DESCRIPTION
Resolves #724

As noted on https://no-color.org:

> Command-line software which adds ANSI color to its output by default should check for the presence of a `NO_COLOR` environment variable that, when present (regardless of its value), prevents the addition of ANSI color.

So I've opted for `os.LookupEnv` to just check for presence.

-----

Also of note, chi isn't necessarily "command-line software" on its own, however the check is fairly simple so I figured it could still be of use.