### PR TITLE
test with go 1.18, update action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,18 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     - name: Test


### PR DESCRIPTION
This PR updates CI to run tests with [Go 1.18](https://go.dev/blog/go1.18).
[actions/setup-go](https://github.com/actions/setup-go#v3) and [actions/checkout](https://github.com/actions/checkout#checkout-v3) are upgraded to the latest version.