### PR TITLE
middleware: fix broken comment on go doc

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -30,14 +30,11 @@ var (
 // http logger with structured logging support.
 //
 // IMPORTANT NOTE: Logger should go before any other middleware that may change
-// the response, such as `middleware.Recoverer`. Example:
-//
-// ```go
-// r := chi.NewRouter()
-// r.Use(middleware.Logger)        // <--<< Logger should come before Recoverer
-// r.Use(middleware.Recoverer)
-// r.Get("/", handler)
-// ```
+// the response, such as middleware.Recoverer. Example:
+//     r := chi.NewRouter()
+//     r.Use(middleware.Logger)        // <--<< Logger should come before Recoverer
+//     r.Use(middleware.Recoverer)
+//     r.Get("/", handler)
 func Logger(next http.Handler) http.Handler {
 	return DefaultLogger(next)
 }


### PR DESCRIPTION
Example code is broken on go doc.
https://pkg.go.dev/github.com/go-chi/chi/middleware#Logger
<img width="976" alt="image" src="https://user-images.githubusercontent.com/1249910/175800431-184b8388-fdf9-4b4f-9735-472c43b483e6.png">
