### PR TITLE
Update logging example to use preview version of new log/slog

### DIFF
--- a/_examples/logging/main.go
+++ b/_examples/logging/main.go
@@ -1,41 +1,42 @@
-//
 // Custom Structured Logger
 // ========================
 // This example demonstrates how to use middleware.RequestLogger,
 // middleware.LogFormatter and middleware.LogEntry to build a structured
-// logger using the amazing sirupsen/logrus package as the logging
+// logger using the preview version of the new log/slog package as the logging
 // backend.
 //
 // Also: check out https://github.com/goware/httplog for an improved context
 // logger with support for HTTP request logging, based on the example below.
-//
 package main
 
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"time"
+
+	"golang.org/x/exp/slog"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
-
-	// Setup the logger backend using sirupsen/logrus and configure
-	// it to use a custom JSONFormatter. See the logrus docs for how to
-	// configure the backend at github.com/sirupsen/logrus
-	logger := logrus.New()
-	logger.Formatter = &logrus.JSONFormatter{
-		// disable, as we set our own
-		DisableTimestamp: true,
-	}
+	// Setup a JSON handler for the new log/slog library
+	slogJSONHandler := slog.HandlerOptions{
+		// Remove default time slog.Attr, we create our own later
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}.NewJSONHandler(os.Stdout)
 
 	// Routes
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
-	r.Use(NewStructuredLogger(logger))
+	r.Use(NewStructuredLoggerMiddleware(slogJSONHandler))
 	r.Use(middleware.Recoverer)
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
@@ -43,76 +44,76 @@ func main() {
 	})
 	r.Get("/wait", func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(1 * time.Second)
-		LogEntrySetField(r, "wait", true)
+		StructuredLogEntrySetField(r, "wait", true)
 		w.Write([]byte("hi"))
 	})
 	r.Get("/panic", func(w http.ResponseWriter, r *http.Request) {
 		panic("oops")
 	})
+	r.Get("/add_fields", func(w http.ResponseWriter, r *http.Request) {
+		StructuredLogEntrySetFields(r, map[string]interface{}{"foo": "bar", "bar": "foo"})
+	})
 	http.ListenAndServe(":3333", r)
 }
 
-// StructuredLogger is a simple, but powerful implementation of a custom structured
-// logger backed on logrus. I encourage users to copy it, adapt it and make it their
+// StructuredLogHandler is a simple, but powerful implementation of a custom structured
+// logger backed on log/slog. I encourage users to copy it, adapt it and make it their
 // own. Also take a look at https://github.com/go-chi/httplog for a dedicated pkg based
 // on this work, designed for context-based http routers.
 
-func NewStructuredLogger(logger *logrus.Logger) func(next http.Handler) http.Handler {
-	return middleware.RequestLogger(&StructuredLogger{logger})
+func NewStructuredLoggerMiddleware(handler slog.Handler) func(next http.Handler) http.Handler {
+	return middleware.RequestLogger(&StructuredLogHandler{Handler: handler})
 }
 
-type StructuredLogger struct {
-	Logger *logrus.Logger
+type StructuredLogHandler struct {
+	Handler slog.Handler
 }
 
-func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
-	entry := &StructuredLoggerEntry{Logger: logrus.NewEntry(l.Logger)}
-	logFields := logrus.Fields{}
-
-	logFields["ts"] = time.Now().UTC().Format(time.RFC1123)
+func (l *StructuredLogHandler) NewLogEntry(r *http.Request) middleware.LogEntry {
+	var slogAttrs []slog.Attr
+	slogAttrs = append(slogAttrs, slog.String("ts", time.Now().UTC().Format(time.RFC1123)))
 
 	if reqID := middleware.GetReqID(r.Context()); reqID != "" {
-		logFields["req_id"] = reqID
+		slogAttrs = append(slogAttrs, slog.String("req_id", reqID))
 	}
 
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
 	}
-	logFields["http_scheme"] = scheme
-	logFields["http_proto"] = r.Proto
-	logFields["http_method"] = r.Method
 
-	logFields["remote_addr"] = r.RemoteAddr
-	logFields["user_agent"] = r.UserAgent()
+	handler := l.Handler.WithAttrs(append(slogAttrs,
+		slog.String("http_scheme", scheme),
+		slog.String("http_proto", r.Proto),
+		slog.String("http_method", r.Method),
+		slog.String("remote_addr", r.RemoteAddr),
+		slog.String("user_agent", r.UserAgent()),
+		slog.String("uri", fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI))))
 
-	logFields["uri"] = fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI)
+	entry := StructuredLogEntry{Logger: slog.New(handler)}
 
-	entry.Logger = entry.Logger.WithFields(logFields)
+	entry.Logger.LogAttrs(slog.LevelInfo, "request started", slogAttrs...)
 
-	entry.Logger.Infoln("request started")
-
-	return entry
+	return &entry
 }
 
-type StructuredLoggerEntry struct {
-	Logger logrus.FieldLogger
+type StructuredLogEntry struct {
+	Logger *slog.Logger
 }
 
-func (l *StructuredLoggerEntry) Write(status, bytes int, header http.Header, elapsed time.Duration, extra interface{}) {
-	l.Logger = l.Logger.WithFields(logrus.Fields{
-		"resp_status": status, "resp_bytes_length": bytes,
-		"resp_elapsed_ms": float64(elapsed.Nanoseconds()) / 1000000.0,
-	})
-
-	l.Logger.Infoln("request complete")
+func (l *StructuredLogEntry) Write(status, bytes int, header http.Header, elapsed time.Duration, extra interface{}) {
+	l.Logger.LogAttrs(slog.LevelInfo, "request complete",
+		slog.Int("resp_status", status),
+		slog.Int("resp_byte_length", bytes),
+		slog.Float64("resp_elapsed_ms", float64(elapsed.Nanoseconds())/1000000.0),
+	)
 }
 
-func (l *StructuredLoggerEntry) Panic(v interface{}, stack []byte) {
-	l.Logger = l.Logger.WithFields(logrus.Fields{
-		"stack": string(stack),
-		"panic": fmt.Sprintf("%+v", v),
-	})
+func (l *StructuredLogEntry) Panic(v interface{}, stack []byte) {
+	l.Logger.LogAttrs(slog.LevelInfo, "",
+		slog.String("stack", string(stack)),
+		slog.String("panic", fmt.Sprintf("%+v", v)),
+	)
 }
 
 // Helper methods used by the application to get the request-scoped
@@ -122,19 +123,21 @@ func (l *StructuredLoggerEntry) Panic(v interface{}, stack []byte) {
 // passes through the handler chain, which at any point can be logged
 // with a call to .Print(), .Info(), etc.
 
-func GetLogEntry(r *http.Request) logrus.FieldLogger {
-	entry := middleware.GetLogEntry(r).(*StructuredLoggerEntry)
+func GetStructuredLogEntry(r *http.Request) *slog.Logger {
+	entry := middleware.GetLogEntry(r).(*StructuredLogEntry)
 	return entry.Logger
 }
 
-func LogEntrySetField(r *http.Request, key string, value interface{}) {
-	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
-		entry.Logger = entry.Logger.WithField(key, value)
+func StructuredLogEntrySetField(r *http.Request, key string, value interface{}) {
+	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLogEntry); ok {
+		entry.Logger = entry.Logger.With(key, value)
 	}
 }
 
-func LogEntrySetFields(r *http.Request, fields map[string]interface{}) {
-	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
-		entry.Logger = entry.Logger.WithFields(fields)
+func StructuredLogEntrySetFields(r *http.Request, fields map[string]interface{}) {
+	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLogEntry); ok {
+		for k, v := range fields {
+			entry.Logger = entry.Logger.With(k, v)
+		}
 	}
 }

--- a/_examples/logging/main.go
+++ b/_examples/logging/main.go
@@ -44,14 +44,14 @@ func main() {
 	})
 	r.Get("/wait", func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(1 * time.Second)
-		StructuredLogEntrySetField(r, "wait", true)
+		LogEntrySetField(r, "wait", true)
 		w.Write([]byte("hi"))
 	})
 	r.Get("/panic", func(w http.ResponseWriter, r *http.Request) {
 		panic("oops")
 	})
 	r.Get("/add_fields", func(w http.ResponseWriter, r *http.Request) {
-		StructuredLogEntrySetFields(r, map[string]interface{}{"foo": "bar", "bar": "foo"})
+		LogEntrySetFields(r, map[string]interface{}{"foo": "bar", "bar": "foo"})
 	})
 	http.ListenAndServe(":3333", r)
 }
@@ -123,18 +123,18 @@ func (l *StructuredLoggerEntry) Panic(v interface{}, stack []byte) {
 // passes through the handler chain, which at any point can be logged
 // with a call to .Print(), .Info(), etc.
 
-func GetStructuredLogEntry(r *http.Request) *slog.Logger {
+func GetLogEntry(r *http.Request) *slog.Logger {
 	entry := middleware.GetLogEntry(r).(*StructuredLoggerEntry)
 	return entry.Logger
 }
 
-func StructuredLogEntrySetField(r *http.Request, key string, value interface{}) {
+func LogEntrySetField(r *http.Request, key string, value interface{}) {
 	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
 		entry.Logger = entry.Logger.With(key, value)
 	}
 }
 
-func StructuredLogEntrySetFields(r *http.Request, fields map[string]interface{}) {
+func LogEntrySetFields(r *http.Request, fields map[string]interface{}) {
 	if entry, ok := r.Context().Value(middleware.LogEntryCtxKey).(*StructuredLoggerEntry); ok {
 		for k, v := range fields {
 			entry.Logger = entry.Logger.With(k, v)


### PR DESCRIPTION
Addresses #761 by replacing the logrus implementation with the [preview version](https://pkg.go.dev/golang.org/x/exp/slog) of the new `log/slog` package.

- Updated names of three helper functions at the bottom (prepended `Structured` to all three).
- Added a new route to exercise the `StructuredLogEntrySetFields()` function that wasn't being called.

<details><summary>Output of new logger for route: "/"</summary>
<code>
{"level":"INFO","msg":"request started","ts":"Sat, 17 Dec 2022 07:35:04 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000001","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53853","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/","ts":"Sat, 17 Dec 2022 07:35:04 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000001"}

{"level":"INFO","msg":"request complete","ts":"Sat, 17 Dec 2022 07:35:04 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000001","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53853","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/","resp_status":200,"resp_byte_length":7,"resp_elapsed_ms":0.012206}
</code>
</details>

<details><summary>Output of new logger for route: "/wait"</summary>
<code>
{"level":"INFO","msg":"request started","ts":"Sat, 17 Dec 2022 07:35:07 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000002","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53854","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/wait","ts":"Sat, 17 Dec 2022 07:35:07 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000002"}

{"level":"INFO","msg":"request complete","ts":"Sat, 17 Dec 2022 07:35:07 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000002","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53854","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/wait","wait":true,"resp_status":200,"resp_byte_length":2,"resp_elapsed_ms":1000.626244}
</code>
</details>

<details><summary>Output of new logger for route: "/panic"</summary>
<code>
{"level":"INFO","msg":"request started","ts":"Sat, 17 Dec 2022 07:35:13 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000003","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53856","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/panic","ts":"Sat, 17 Dec 2022 07:35:13 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000003"}

{"level":"INFO","msg":"","ts":"Sat, 17 Dec 2022 07:35:13 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000003","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53856","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/panic","stack":"goroutine 50 [running]:\nruntime/debug.Stack()\n\t/usr/local/opt/go/libexec/src/runtime/debug/stack.go:24 +0x65\ngithub.com/go-chi/chi/v5/middleware.Recoverer.func1.1()\n\t/Users/brady.briggs/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.8/middleware/recoverer.go:34 +0x99\npanic({0x12aee80, 0x1387b10})\n\t/usr/local/opt/go/libexec/src/runtime/panic.go:884 +0x212\nmain.main.func4({0x1305878?, 0x0?}, 0xc0000b00a0?)\n\t/Users/brady.briggs/Documents/development/github.com/ydarb/chi/_examples/logging/main.go:51 +0x27\nnet/http.HandlerFunc.ServeHTTP(0x12be280?, {0x29603418?, 0xc00009c1c0?}, 0xc0000a2004?)\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109 +0x2f\ngithub.com/go-chi/chi/v5.(*Mux).routeHTTP(0xc0002122a0, {0x29603418, 0xc00009c1c0}, 0xc0000a0300)\n\t/Users/brady.briggs/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.8/mux.go:444 +0x216\nnet/http.HandlerFunc.ServeHTTP(0x100e767?, {0x29603418?, 0xc00009c1c0?}, 0x152d801?)\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109 +0x2f\ngithub.com/go-chi/chi/v5/middleware.Recoverer.func1({0x29603418?, 0xc00009c1c0?}, 0xc000092200?)\n\t/Users/brady.briggs/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.8/middleware/recoverer.go:43 +0x83\nnet/http.HandlerFunc.ServeHTTP(0xc0000a0200?, {0x29603418?, 0xc00009c1c0?}, 0x107cdbe?)\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109 +0x2f\ngithub.com/go-chi/chi/v5/middleware.RequestLogger.func1.1({0x138ae80, 0xc0000ac000}, 0xc0000a0200)\n\t/Users/brady.briggs/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.8/middleware/logger.go:54 +0x17d\nnet/http.HandlerFunc.ServeHTTP(0x138b3a0?, {0x138ae80?, 0xc0000ac000?}, 0x13874f0?)\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109 +0x2f\ngithub.com/go-chi/chi/v5/middleware.RequestID.func1({0x138ae80, 0xc0000ac000}, 0xc0000a0100)\n\t/Users/brady.briggs/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.8/middleware/request_id.go:76 +0x22d\nnet/http.HandlerFunc.ServeHTTP(0x138b2f8?, {0x138ae80?, 0xc0000ac000?}, 0x152d7f0?)\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109 +0x2f\ngithub.com/go-chi/chi/v5.(*Mux).ServeHTTP(0xc0002122a0, {0x138ae80, 0xc0000ac000}, 0xc0000a0000)\n\t/Users/brady.briggs/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.8/mux.go:90 +0x310\nnet/http.serverHandler.ServeHTTP({0xc000092090?}, {0x138ae80, 0xc0000ac000}, 0xc0000a0000)\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2947 +0x30c\nnet/http.(*conn).serve(0xc000096000, {0x138b3a0, 0xc000203560})\n\t/usr/local/opt/go/libexec/src/net/http/server.go:1991 +0x607\ncreated by net/http.(*Server).Serve\n\t/usr/local/opt/go/libexec/src/net/http/server.go:3102 +0x4db\n","panic":"oops"}
</code>
</details>

<details><summary>Output of new logger for route: "/add_fields"</summary>
<code>
{"level":"INFO","msg":"request complete","ts":"Sat, 17 Dec 2022 07:35:13 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000003","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53856","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/panic","resp_status":500,"resp_byte_length":0,"resp_elapsed_ms":2.039354}

{"level":"INFO","msg":"request started","ts":"Sat, 17 Dec 2022 07:35:21 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000004","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53857","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/add_fields","ts":"Sat, 17 Dec 2022 07:35:21 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000004"}
{"level":"INFO","msg":"request complete","ts":"Sat, 17 Dec 2022 07:35:21 UTC","req_id":"bbriggs-mac.local/IDKVRVdgFj-000004","http_scheme":"http","http_proto":"HTTP/1.1","http_method":"GET","remote_addr":"127.0.0.1:53857","user_agent":"curl/7.84.0","uri":"http://127.0.0.1:3333/add_fields","foo":"bar","bar":"foo","resp_status":0,"resp_byte_length":0,"resp_elapsed_ms":0.021186}
</code>
</details>