### PR TITLE
Use timestamps in GMT format per RFC2616

### DIFF
--- a/middleware/nocache.go
+++ b/middleware/nocache.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Unix epoch time
-var epoch = time.Unix(0, 0).Format(http.TimeFormat)
+var epoch = time.Unix(0, 0).UTC().Format(http.TimeFormat)
 
 // Taken from https://github.com/mytrile/nocache
 var noCacheHeaders = map[string]string{

--- a/middleware/nocache.go
+++ b/middleware/nocache.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Unix epoch time
-var epoch = time.Unix(0, 0).Format(time.RFC1123)
+var epoch = time.Unix(0, 0).Format(http.TimeFormat)
 
 // Taken from https://github.com/mytrile/nocache
 var noCacheHeaders = map[string]string{


### PR DESCRIPTION
it seems http.TimeFormat used to format time that related with http header, and nocache middleware was not use that(time.RFC1123 instead)