### PR TITLE
Correct doc comment

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -140,7 +140,7 @@ func NewCompressor(level int, types ...string) *Compressor {
 //  import brotli_enc "gopkg.in/kothar/brotli-go.v0/enc"
 //
 //  compressor := middleware.NewCompressor(5, "text/html")
-//  compressor.SetEncoder("br", func(w http.ResponseWriter, level int) io.Writer {
+//  compressor.SetEncoder("br", func(w io.Writer, level int) io.Writer {
 //    params := brotli_enc.NewBrotliParams()
 //    params.SetQuality(level)
 //    return brotli_enc.NewBrotliWriter(params, w)


### PR DESCRIPTION
The function must be of type middleware.EncoderFunc, and this has an io.Writer as its first argument. See https://github.com/go-chi/chi/issues/773#issuecomment-1360940386.