### PR TITLE
Fix duplicate fields in logging example

### DIFF
--- a/_examples/logging/main.go
+++ b/_examples/logging/main.go
@@ -92,7 +92,7 @@ func (l *StructuredLogger) NewLogEntry(r *http.Request) middleware.LogEntry {
 
 	entry := StructuredLoggerEntry{Logger: slog.New(handler)}
 
-	entry.Logger.LogAttrs(slog.LevelInfo, "request started", logFields...)
+	entry.Logger.LogAttrs(slog.LevelInfo, "request started")
 
 	return &entry
 }


### PR DESCRIPTION
In some cases, logs will contain duplicate fields.

Here's an example.

```json
{
    "level": "INFO",
    "msg": "request started",
    "ts": "Sat, 07 Jan 2023 02:15:16 UTC",  // Duplicate
    "req_id": "hostname/MlcrKoeXEN-000001",  // Duplicate
    "http_scheme": "http",
    "http_proto": "HTTP/1.1",
    "http_method": "GET",
    "remote_addr": "127.0.0.1:52572",
    "user_agent": "curl/7.85.0",
    "uri": "http://localhost:3333/",
    "ts": "Sat, 07 Jan 2023 02:15:16 UTC",  // Duplicate
    "req_id": "hostname/MlcrKoeXEN-000001"  // Duplicate
}
```

Since `entry.Logger` already contains all the fields we want to specify, there is no need to pass in `logFields...` again.

Here's the output after the change.

```json
{
    "level": "INFO",
    "msg": "request started",
    "ts": "Sat, 07 Jan 2023 02:15:37 UTC",
    "req_id": "hostname/Hkbv1XUDxM-000001",
    "http_scheme": "http",
    "http_proto": "HTTP/1.1",
    "http_method": "GET",
    "remote_addr": "127.0.0.1:52581",
    "user_agent": "curl/7.85.0",
    "uri": "http://localhost:3333/"
}
```