### PR TITLE
Make CleanPath middleware work with other routers

### DIFF
--- a/middleware/clean_path.go
+++ b/middleware/clean_path.go
@@ -12,17 +12,19 @@ import (
 func CleanPath(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rctx := chi.RouteContext(r.Context())
-
-		routePath := rctx.RoutePath
+		
+		var routePath string
+		if rctx != nil {
+			routePath = rctx.RoutePath
+		}
 		if routePath == "" {
 			if r.URL.RawPath != "" {
 				routePath = r.URL.RawPath
 			} else {
 				routePath = r.URL.Path
 			}
-			rctx.RoutePath = path.Clean(routePath)
 		}
-
+		rctx.RoutePath = path.Clean(routePath)
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
The rctx is not checked and could be nil if the function isn't used with a chi.Router. 
It ends up in a panic.

Additional point: the cleaning only happens in the rctx.RoutePath is an empty string. If a function like [GetHead](https://github.com/go-chi/chi/blob/v1.5.4/middleware/get_head.go#L10) [¶](https://pkg.go.dev/github.com/go-chi/chi/middleware#GetHead) is called before it won't clean the path. 