### PR TITLE
Don't strip trailing slash if it's escaped in StripSlashes middlware

### DIFF
--- a/middleware/strip_test.go
+++ b/middleware/strip_test.go
@@ -48,7 +48,16 @@ func TestStripSlashes(t *testing.T) {
 	if _, resp := testRequest(t, ts, "GET", "/accounts/admin/", nil); resp != "admin" {
 		t.Fatalf(resp)
 	}
+	if _, resp := testRequest(t, ts, "GET", "/accounts/escaped%2F", nil); resp != "escaped%2F" {
+		t.Fatalf(resp)
+	}
+	if _, resp := testRequest(t, ts, "GET", "/accounts/escaped%2F/", nil); resp != "escaped%2F" {
+		t.Fatalf(resp)
+	}
 	if _, resp := testRequest(t, ts, "GET", "/nothing-here", nil); resp != "nothing here" {
+		t.Fatalf(resp)
+	}
+	if _, resp := testRequest(t, ts, "GET", "/%2F", nil); resp != "nothing here" {
 		t.Fatalf(resp)
 	}
 }
@@ -95,6 +104,9 @@ func TestStripSlashesInRoute(t *testing.T) {
 		t.Fatalf(resp)
 	}
 	if _, resp := testRequest(t, ts, "GET", "/accounts/admin/query/", nil); resp != "admin" {
+		t.Fatalf(resp)
+	}
+	if _, resp := testRequest(t, ts, "GET", "/accounts/admin/query%2F", nil); resp != "nothing here" {
 		t.Fatalf(resp)
 	}
 }


### PR DESCRIPTION
This fixes an edge case where a path ending in a trailing encoded slash `%2F` is incorrectly stripped and rctx.RoutePath is set to the unescaped Path, resulting in routing errors.

The specific edge case in my project is:
- rctx is nil
- rctx.RoutePath is empty
- r.URL.RawPath contains multiple escaped slashes in various places
- rctx.RoutePath is set to the unescaped values contained in r.URL.Path
- The Mux no longer matches the route `/link_resolver/{url}` because all `%2F` are now `/`

A similar issue also exists in `RedirectSlashes`, I can open a second PR for that as well if you'd like.