### PR TITLE
go 1.20.x in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x]
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Update CI to run tests with [Go 1.20](https://go.dev/blog/go1.20)