### PR TITLE
chore: recoverer middleware skip write header on upgrade connection

### DIFF
--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -36,7 +36,9 @@ func Recoverer(next http.Handler) http.Handler {
 					PrintPrettyStack(rvr)
 				}
 
-				w.WriteHeader(http.StatusInternalServerError)
+				if r.Header.Get("Connection") != "Upgrade" {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
 			}
 		}()
 


### PR DESCRIPTION
Fix #661 

skip write header when connection has been upgrade