### PR TITLE
Use raw path in middleware to strip slash

### DIFF
--- a/middleware/strip.go
+++ b/middleware/strip.go
@@ -16,6 +16,8 @@ func StripSlashes(next http.Handler) http.Handler {
 		rctx := chi.RouteContext(r.Context())
 		if rctx != nil && rctx.RoutePath != "" {
 			path = rctx.RoutePath
+		} else if r.URL.RawPath != "" {
+			path = r.URL.RawPath
 		} else {
 			path = r.URL.Path
 		}
@@ -43,6 +45,8 @@ func RedirectSlashes(next http.Handler) http.Handler {
 		rctx := chi.RouteContext(r.Context())
 		if rctx != nil && rctx.RoutePath != "" {
 			path = rctx.RoutePath
+		} else if r.URL.RawPath != "" {
+			path = r.URL.RawPath
 		} else {
 			path = r.URL.Path
 		}


### PR DESCRIPTION
Fix #798.

Follow what has been done in other middlewares, like [CleanPath](
https://github.com/go-chi/chi/blob/51068a747f1a32dbce24c499561a0f5ecb7f7158/middleware/clean_path.go#L17-L22)


And some middlewares may have the same issue too, I don't check them.