### PR TITLE
Add error handling for nil RouteContext in URLFormat

### DIFF
--- a/middleware/url_format.go
+++ b/middleware/url_format.go
@@ -8,6 +8,10 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+const (
+	errRouteContextNil = "RouteContext was nil."
+)
+
 var (
 	// URLFormatCtxKey is the context.Context key to store the URL format data
 	// for a request.
@@ -52,7 +56,12 @@ func URLFormat(next http.Handler) http.Handler {
 		path := r.URL.Path
 
 		rctx := chi.RouteContext(r.Context())
-		if rctx != nil && rctx.RoutePath != "" {
+		if rctx == nil {
+			http.Error(w, errRouteContextNil, http.StatusInternalServerError)
+			return
+		}
+
+		if rctx.RoutePath != "" {
 			path = rctx.RoutePath
 		}
 


### PR DESCRIPTION
Fix https://github.com/go-chi/chi/issues/839
Ref https://github.com/go-chi/chi/pull/718

In the current URLFormat middleware implementation, the absence of rctx (Route Context) could lead to unexpected behavior or panic errors in subsequent processing.

To avoid this, I have prioritized not allowing unexpected behavior by implementing error handling for the cases where rctx is missing or nil. Now, instead of failing silently or causing a panic error, the system will return a proper HTTP error response.

This change ensures that the system behaves consistently and avoids potential pitfalls that might arise from missing or improperly initialized rctx.