### PR TITLE
feat(middleware): add sunset/deprecation header middleware

### DIFF
--- a/middleware/sunset.go
+++ b/middleware/sunset.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+)
+
+// Sunset set Deprecation/Sunset header to response
+// This can be used to enable Sunset in a route or a route group
+// For more at: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header-02
+func Sunset(sunsetAt *time.Time, links ...string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if sunsetAt != nil {
+				w.Header().Set("Sunset", sunsetAt.Format(http.TimeFormat))
+				w.Header().Set("Deprecation", sunsetAt.Format(http.TimeFormat))
+
+				for i, link := range links {
+					if i == 0 {
+						w.Header().Set("Link", link)
+						continue
+					}
+					w.Header().Add("Link", link)
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/middleware/sunset.go
+++ b/middleware/sunset.go
@@ -7,7 +7,7 @@ import (
 
 // Sunset set Deprecation/Sunset header to response
 // This can be used to enable Sunset in a route or a route group
-// For more at: https://www.rfc-editor.org/rfc/rfc8594.html
+// For more: https://www.rfc-editor.org/rfc/rfc8594.html
 func Sunset(sunsetAt time.Time, links ...string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -15,11 +15,7 @@ func Sunset(sunsetAt time.Time, links ...string) func(http.Handler) http.Handler
 				w.Header().Set("Sunset", sunsetAt.Format(http.TimeFormat))
 				w.Header().Set("Deprecation", sunsetAt.Format(http.TimeFormat))
 
-				for i, link := range links {
-					if i == 0 {
-						w.Header().Set("Link", link)
-						continue
-					}
+				for _, link := range links {
 					w.Header().Add("Link", link)
 				}
 			}

--- a/middleware/sunset.go
+++ b/middleware/sunset.go
@@ -7,11 +7,11 @@ import (
 
 // Sunset set Deprecation/Sunset header to response
 // This can be used to enable Sunset in a route or a route group
-// For more at: https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-deprecation-header-02
-func Sunset(sunsetAt *time.Time, links ...string) func(http.Handler) http.Handler {
+// For more at: https://www.rfc-editor.org/rfc/rfc8594.html
+func Sunset(sunsetAt time.Time, links ...string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if sunsetAt != nil {
+			if !sunsetAt.IsZero() {
 				w.Header().Set("Sunset", sunsetAt.Format(http.TimeFormat))
 				w.Header().Set("Deprecation", sunsetAt.Format(http.TimeFormat))
 

--- a/middleware/sunset_test.go
+++ b/middleware/sunset_test.go
@@ -18,7 +18,7 @@ func TestSunset(t *testing.T) {
 		r := chi.NewRouter()
 
 		sunsetAt := time.Date(2025, 12, 24, 10, 20, 0, 0, time.UTC)
-		r.Use(Sunset(&sunsetAt))
+		r.Use(Sunset(sunsetAt))
 
 		var sunset, deprecation string
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +50,7 @@ func TestSunset(t *testing.T) {
 
 		sunsetAt := time.Date(2025, 12, 24, 10, 20, 0, 0, time.UTC)
 		deprecationLink := "https://example.com/v1/deprecation-details"
-		r.Use(Sunset(&sunsetAt, deprecationLink))
+		r.Use(Sunset(sunsetAt, deprecationLink))
 
 		var sunset, deprecation, link string
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
@@ -89,10 +89,10 @@ func main() {
 	r := chi.NewRouter()
 
 	sunsetAt := time.Date(2025, 12, 24, 10, 20, 0, 0, time.UTC)
-	r.Use(middleware.Sunset(&sunsetAt))
+	r.Use(middleware.Sunset(sunsetAt))
 
 	// can provide additional link for updated resource
-	// r.Use(middleware.Sunset(&sunsetAt, "https://example.com/v1/deprecation-details"))
+	// r.Use(middleware.Sunset(sunsetAt, "https://example.com/v1/deprecation-details"))
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("This endpoint will be removed soon"))

--- a/middleware/sunset_test.go
+++ b/middleware/sunset_test.go
@@ -1,0 +1,104 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestSunset(t *testing.T) {
+
+	t.Run("Sunset without link", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		r := chi.NewRouter()
+
+		sunsetAt := time.Date(2025, 12, 24, 10, 20, 0, 0, time.UTC)
+		r.Use(Sunset(&sunsetAt))
+
+		var sunset, deprecation string
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			clonedHeader := w.Header().Clone()
+			sunset = clonedHeader.Get("Sunset")
+			deprecation = clonedHeader.Get("Deprecation")
+			w.Write([]byte("I'll be unavailable soon"))
+		})
+		r.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatal("Response Code should be 200")
+		}
+
+		if sunset != "Wed, 24 Dec 2025 10:20:00 GMT" {
+			t.Fatal("Test get sunset error.", sunset)
+		}
+
+		if deprecation != "Wed, 24 Dec 2025 10:20:00 GMT" {
+			t.Fatal("Test get deprecation error.")
+		}
+	})
+
+	t.Run("Sunset with link", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		r := chi.NewRouter()
+
+		sunsetAt := time.Date(2025, 12, 24, 10, 20, 0, 0, time.UTC)
+		deprecationLink := "https://example.com/v1/deprecation-details"
+		r.Use(Sunset(&sunsetAt, deprecationLink))
+
+		var sunset, deprecation, link string
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			clonedHeader := w.Header().Clone()
+			sunset = clonedHeader.Get("Sunset")
+			deprecation = clonedHeader.Get("Deprecation")
+			link = clonedHeader.Get("Link")
+
+			w.Write([]byte("I'll be unavailable soon"))
+		})
+
+		r.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatal("Response Code should be 200")
+		}
+
+		if sunset != "Wed, 24 Dec 2025 10:20:00 GMT" {
+			t.Fatal("Test get sunset error.", sunset)
+		}
+
+		if deprecation != "Wed, 24 Dec 2025 10:20:00 GMT" {
+			t.Fatal("Test get deprecation error.")
+		}
+
+		if link != deprecationLink {
+			t.Fatal("Test get deprecation link error.")
+		}
+	})
+
+}
+
+/**
+EXAMPLE USAGES
+func main() {
+	r := chi.NewRouter()
+
+	sunsetAt := time.Date(2025, 12, 24, 10, 20, 0, 0, time.UTC)
+	r.Use(middleware.Sunset(&sunsetAt))
+
+	// can provide additional link for updated resource
+	// r.Use(middleware.Sunset(&sunsetAt, "https://example.com/v1/deprecation-details"))
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("This endpoint will be removed soon"))
+	})
+
+	log.Println("Listening on port: 3000")
+	http.ListenAndServe(":3000", r)
+}
+**/


### PR DESCRIPTION
This PR will include a `Sunset` middleware which can be used to deprecate an endpoint or a group of endpoints.

For additional information please go through the [LINK](https://www.rfc-editor.org/rfc/rfc8594.html)

**Example usages**

```go
func main() {
	r := chi.NewRouter()

	sunsetAt := time.Date(2025, 12, 24, 10, 20, 0, 0, time.UTC)
	r.Use(middleware.Sunset(sunsetAt))

	// can provide additional link for updated resource
	// r.Use(middleware.Sunset(sunsetAt, "https://example.com/v1/deprecation-details"))

	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
		w.Write([]byte("This endpoint will be removed soon"))
	})

	log.Println("Listening on port: 3000")
	http.ListenAndServe(":3000", r)
}

```