### PR TITLE
Removes ambiguity around "fresh middleware stack" in GoDoc

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -250,7 +250,7 @@ func (mx *Mux) With(middlewares ...func(http.Handler) http.Handler) Router {
 	return im
 }
 
-// Group creates a new inline-Mux with a fresh middleware stack. It's useful
+// Group creates a new inline-Mux with a copy of middleware stack. It's useful
 // for a group of handlers along the same routing path that use an additional
 // set of middlewares. See _examples/.
 func (mx *Mux) Group(fn func(r Router)) Router {
@@ -261,9 +261,8 @@ func (mx *Mux) Group(fn func(r Router)) Router {
 	return im
 }
 
-// Route creates a new Mux with a fresh middleware stack and mounts it
-// along the `pattern` as a subrouter. Effectively, this is a short-hand
-// call to Mount. See _examples/.
+// Route creates a new Mux and mounts it along the `pattern` as a subrouter.
+// Effectively, this is a short-hand call to Mount. See _examples/.
 func (mx *Mux) Route(pattern string, fn func(r Router)) Router {
 	if fn == nil {
 		panic(fmt.Sprintf("chi: attempting to Route() a nil subrouter on '%s'", pattern))


### PR DESCRIPTION
#### For `Group()`:
`fresh` implies that a new empty middleware stack is created, while in fact the parent's stack is copied.

#### For `Route()`:
Looks like `with a fresh middleware stack` was added to emphasize that while the parent middleware stack is frozen, one can still add middlewares to new router's stack before starting to define routes on it.

In my opinion this is clear from `creates a new Mux`. Adding `with a fresh middleware stack` makes it more obscure that the parent middleware stack will be executed wrapping the new one.