### PR TITLE
The minimum supported version is Go 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-chi/chi/v5
 
-go 1.14
+go 1.15


### PR DESCRIPTION
This [commit](https://github.com/go-chi/chi/commit/2590e818906c30b869701e57111e8af930707abd) changed CI to test on Go versions 1.15+. So, I updated `go.mod` for using Go 1.15.