### PR TITLE
bump setup-go and checkout action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,13 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
+        cache: false
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}
     - name: Test


### PR DESCRIPTION
This PR updates CI to use the latest versions of [actions/setup-go](https://github.com/actions/setup-go) and [actions/checkout](https://github.com/actions/checkout).

`check-latest: true` is to ensure the latest patch version is used.
`cache: false` is to keep the same default behaviour as in v3 and to avoid warning when looking for `go.sum` in the repository.