### PR TITLE
feat: update HTTP method parsing in patterns for `Handle` and `HandleFunc`

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -119,6 +119,12 @@ func (mx *Mux) Handle(pattern string, handler http.Handler) {
 // HandleFunc adds the route `pattern` that matches any http method to
 // execute the `handlerFn` http.HandlerFunc.
 func (mx *Mux) HandleFunc(pattern string, handlerFn http.HandlerFunc) {
+	parts := strings.SplitN(pattern, " ", 2)
+	if len(parts) == 2 {
+		mx.Method(parts[0], parts[1], handlerFn)
+		return
+	}
+
 	mx.handle(mALL, pattern, handlerFn)
 }
 

--- a/mux.go
+++ b/mux.go
@@ -109,15 +109,7 @@ func (mx *Mux) Use(middlewares ...func(http.Handler) http.Handler) {
 func (mx *Mux) Handle(pattern string, handler http.Handler) {
 	parts := strings.SplitN(pattern, " ", 2)
 	if len(parts) == 2 {
-		methodStr := strings.ToUpper(parts[0])
-		path := parts[1]
-
-		method, ok := methodMap[methodStr]
-		if !ok {
-			panic("chi: invalid HTTP method specified in pattern: " + methodStr)
-		}
-
-		mx.handle(method, path, handler)
+		mx.Method(parts[0], parts[1], handler)
 		return
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -695,38 +695,28 @@ func TestMuxHandlePatternValidation(t *testing.T) {
 				}
 			}()
 
-			r := NewRouter()
-			r.Handle(tc.pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r1 := NewRouter()
+			r1.Handle(tc.pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte(tc.expectedBody))
 			}))
 
-			if !tc.shouldPanic {
-				// Use testRequest for valid patterns
-				ts := httptest.NewServer(r)
-				defer ts.Close()
-
-				resp, body := testRequest(t, ts, tc.method, tc.path, nil)
-				if body != tc.expectedBody || resp.StatusCode != tc.expectedStatus {
-					t.Errorf("Expected status %d and body %s; got status %d and body %s for pattern %s",
-						tc.expectedStatus, tc.expectedBody, resp.StatusCode, body, tc.pattern)
-				}
-			}
-
 			// Test that HandleFunc also handles method patterns
-			r = NewRouter()
-			r.HandleFunc(tc.pattern, func(w http.ResponseWriter, r *http.Request) {
+			r2 := NewRouter()
+			r2.HandleFunc(tc.pattern, func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte(tc.expectedBody))
 			})
 
 			if !tc.shouldPanic {
-				// Use testRequest for valid patterns
-				ts := httptest.NewServer(r)
-				defer ts.Close()
+				for _, r := range []Router{r1, r2} {
+					// Use testRequest for valid patterns
+					ts := httptest.NewServer(r)
+					defer ts.Close()
 
-				resp, body := testRequest(t, ts, tc.method, tc.path, nil)
-				if body != tc.expectedBody || resp.StatusCode != tc.expectedStatus {
-					t.Errorf("Expected status %d and body %s; got status %d and body %s for pattern %s",
-						tc.expectedStatus, tc.expectedBody, resp.StatusCode, body, tc.pattern)
+					resp, body := testRequest(t, ts, tc.method, tc.path, nil)
+					if body != tc.expectedBody || resp.StatusCode != tc.expectedStatus {
+						t.Errorf("Expected status %d and body %s; got status %d and body %s for pattern %s",
+							tc.expectedStatus, tc.expectedBody, resp.StatusCode, body, tc.pattern)
+					}
 				}
 			}
 		})

--- a/mux_test.go
+++ b/mux_test.go
@@ -691,7 +691,7 @@ func TestMuxHandlePatternValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil && !tc.shouldPanic {
-					t.Errorf("Unexpected panic for pattern %s", tc.pattern)
+					t.Errorf("Unexpected panic for pattern %s:\n%v", tc.pattern, r)
 				}
 			}()
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -711,6 +711,24 @@ func TestMuxHandlePatternValidation(t *testing.T) {
 						tc.expectedStatus, tc.expectedBody, resp.StatusCode, body, tc.pattern)
 				}
 			}
+
+			// Test that HandleFunc also handles method patterns
+			r = NewRouter()
+			r.HandleFunc(tc.pattern, func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(tc.expectedBody))
+			})
+
+			if !tc.shouldPanic {
+				// Use testRequest for valid patterns
+				ts := httptest.NewServer(r)
+				defer ts.Close()
+
+				resp, body := testRequest(t, ts, tc.method, tc.path, nil)
+				if body != tc.expectedBody || resp.StatusCode != tc.expectedStatus {
+					t.Errorf("Expected status %d and body %s; got status %d and body %s for pattern %s",
+						tc.expectedStatus, tc.expectedBody, resp.StatusCode, body, tc.pattern)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Resolves #899 

Makes the `Mux.HandleFunc` method also support patterns that include an HTTP method. This is the behavior consistent with Go 1.22's `net/http.ServeMux`. Previously, only `Mux.Handle` supported HTTP method patterns according to #897 .

- Made `Mux.HandleFunc` call `Mux.Method` when a method pattern is detected.
- Refactored `Mux.Handle` to call `Mux.Method` instead. Error handling for unrecognized HTTP methods is still kept this way.
- Updated `TestMuxHandlePatternValidation` to also test `Mux.HandleFunc`.