### PR TITLE
feat(mux): support http.Request.PathValue in Go 1.22

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -454,6 +454,10 @@ func (mx *Mux) routeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Find the route
 	if _, _, h := mx.tree.FindRoute(rctx, method, routePath); h != nil {
+		if supportsPathValue {
+			setPathValue(rctx, r)
+		}
+
 		h.ServeHTTP(w, r)
 		return
 	}

--- a/path_value.go
+++ b/path_value.go
@@ -1,0 +1,20 @@
+//go:build go1.22
+// +build go1.22
+
+package chi
+
+import "net/http"
+
+// supportsPathValue is true if the Go version is 1.22 and above.
+//
+// If this is true, `net/http.Request` has methods `SetPathValue` and `PathValue`.
+const supportsPathValue = true
+
+// setPathValue sets the path values in the Request value
+// based on the provided request context.
+func setPathValue(rctx *Context, r *http.Request) {
+	for i, key := range rctx.URLParams.Keys {
+		value := rctx.URLParams.Values[i]
+		r.SetPathValue(key, value)
+	}
+}

--- a/path_value_fallback.go
+++ b/path_value_fallback.go
@@ -1,0 +1,19 @@
+//go:build !go1.22
+// +build !go1.22
+
+package chi
+
+import "net/http"
+
+// supportsPathValue is true if the Go version is 1.22 and above.
+//
+// If this is true, `net/http.Request` has methods `SetPathValue` and `PathValue`.
+const supportsPathValue = false
+
+// setPathValue sets the path values in the Request value
+// based on the provided request context.
+//
+// setPathValue is only supported in Go 1.22 and above so
+// this is just a blank function so that it compiles.
+func setPathValue(rctx *Context, r *http.Request) {
+}

--- a/path_value_test.go
+++ b/path_value_test.go
@@ -1,0 +1,69 @@
+//go:build go1.22
+// +build go1.22
+
+package chi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPathValue(t *testing.T) {
+	testCases := []struct {
+		name         string
+		pattern      string
+		method       string
+		pathKeys     []string
+		requestPath  string
+		expectedBody string
+	}{
+		{
+			name:         "Basic path value",
+			pattern:      "/hubs/{hubID}",
+			method:       "GET",
+			pathKeys:     []string{"hubID"},
+			requestPath:  "/hubs/392",
+			expectedBody: "392",
+		},
+		{
+			name:         "Two path values",
+			pattern:      "/users/{userID}/conversations/{conversationID}",
+			method:       "POST",
+			pathKeys:     []string{"userID", "conversationID"},
+			requestPath:  "/users/Gojo/conversations/2948",
+			expectedBody: "Gojo 2948",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRouter()
+
+			r.Handle(tc.method+" "+tc.pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				pathValues := []string{}
+				for _, pathKey := range tc.pathKeys {
+					pathValue := r.PathValue(pathKey)
+					if pathValue == "" {
+						pathValue = "NOT_FOUND:" + pathKey
+					}
+
+					pathValues = append(pathValues, pathValue)
+				}
+
+				body := strings.Join(pathValues, " ")
+
+				w.Write([]byte(body))
+			}))
+
+			ts := httptest.NewServer(r)
+			defer ts.Close()
+
+			_, body := testRequest(t, ts, tc.method, tc.requestPath, nil)
+			if body != tc.expectedBody {
+				t.Fatalf("expecting %q, got %q", tc.expectedBody, body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves #873

Adds support for getting path values with `http.Request.PathValue`.

In Go versions earlier than 1.22 that don't have that method this shouldn't break them due to conditional compilation.

`http.Request.PathValue` will act as an alias for `chi.URLParam`.

The only syntax in common with 1.22 pattern matching seems to be single-segment matches like `/b/{bucket}`. Other 1.22 features like remaining segment matches (`/files/{path...}`) and matching trailing slashes (`/exact/match/{$}`) are not yet supported. Since they are more complicated and overlap with already-existing Chi functionality, they should be addressed in a separate discussion/PR.

