### PR TITLE
feat: move param logic onto RouteParams type

### DIFF
--- a/context.go
+++ b/context.go
@@ -99,12 +99,7 @@ func (x *Context) Reset() {
 // URLParam returns the corresponding URL parameter value from the request
 // routing context.
 func (x *Context) URLParam(key string) string {
-	for k := len(x.URLParams.Keys) - 1; k >= 0; k-- {
-		if x.URLParams.Keys[k] == key {
-			return x.URLParams.Values[k]
-		}
-	}
-	return ""
+	return x.URLParams.Get(key)
 }
 
 // RoutePattern builds the routing pattern string for the particular
@@ -149,6 +144,17 @@ type RouteParams struct {
 func (s *RouteParams) Add(key, value string) {
 	s.Keys = append(s.Keys, key)
 	s.Values = append(s.Values, value)
+}
+
+// Get returns the corresponding URL parameter value from the route params.
+// If the key appares multiple times, the last value is returned.
+func (s *RouteParams) Get(key string) string {
+	for k := len(s.Keys) - 1; k >= 0; k-- {
+		if s.Keys[k] == key {
+			return s.Values[k]
+		}
+	}
+	return ""
 }
 
 // contextKey is a value for use with context.WithValue. It's used as

--- a/context_test.go
+++ b/context_test.go
@@ -85,3 +85,17 @@ func TestRoutePattern(t *testing.T) {
 		t.Fatal("unexpected route pattern for root: " + p)
 	}
 }
+
+func TestRouteParams(t *testing.T) {
+	rp := &RouteParams{}
+	rp.Add("id", "1")
+	rp.Add("name", "n")
+	rp.Add("id", "2")
+
+	if got, want := rp.Get("id"), "2"; got != want {
+		t.Fatalf("unexpected route param value for key 'id': %s, want: %s", got, want)
+	}
+	if got, want := rp.Get("name"), "n"; got != want {
+		t.Fatalf("unexpected route param value for key 'name': %s, want: %s", got, want)
+	}
+}


### PR DESCRIPTION
This moves the logic for fetching URL parameter values from Context onto the RouteParams type itself. This is helpful if you are working solely with the params themselves and don't need the full context.  This also adds a very simple test for the fetching logic (later values overwrite previous values).

As a concrete use case, I'm working on a request decoder (to plug into go-chi/render) that populates struct fields based on route parameter values.  It seems more appropriate to have an API of:

``` go
func (d *PathDecoder) Decode(dst any, params *chi.RouteParams) error
```

rather than:
``` go
func (d *PathDecoder) Decode(dst any, ctx *chi.Context) error
```