### PR TITLE
reduce size of Context struct from 216 bytes to 208 bytes

### DIFF
--- a/context.go
+++ b/context.go
@@ -74,9 +74,8 @@ type Context struct {
 	// patterns across a stack of sub-routers.
 	RoutePatterns []string
 
-	// methodNotAllowed hint
-	methodNotAllowed bool
 	methodsAllowed   []methodTyp // allowed methods in case of a 405
+	methodNotAllowed bool
 }
 
 // Reset a routing context to its initial state.


### PR DESCRIPTION
optimize memory alignment of `Context` struct