### PR TITLE
changed the NewCompressor logic to be support wildcards in the defaul…

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -15,13 +15,12 @@ import (
 )
 
 var defaultCompressibleContentTypes = []string{
-	"text/html",
-	"text/css",
-	"text/plain",
+	"text/*",
 	"text/javascript",
 	"application/javascript",
 	"application/x-javascript",
 	"application/json",
+	"application/xml",
 	"application/atom+xml",
 	"application/rss+xml",
 	"image/svg+xml",
@@ -66,19 +65,18 @@ func NewCompressor(level int, types ...string) *Compressor {
 	// provided, use the default list.
 	allowedTypes := make(map[string]struct{})
 	allowedWildcards := make(map[string]struct{})
-	if len(types) > 0 {
-		for _, t := range types {
-			if strings.Contains(strings.TrimSuffix(t, "/*"), "*") {
-				panic(fmt.Sprintf("middleware/compress: Unsupported content-type wildcard pattern '%s'. Only '/*' supported", t))
-			}
-			if strings.HasSuffix(t, "/*") {
-				allowedWildcards[strings.TrimSuffix(t, "/*")] = struct{}{}
-			} else {
-				allowedTypes[t] = struct{}{}
-			}
+
+	if len(types) == 0 {
+		types = defaultCompressibleContentTypes
+	}
+
+	for _, t := range types {
+		if strings.Contains(strings.TrimSuffix(t, "/*"), "*") {
+			panic(fmt.Sprintf("middleware/compress: Unsupported content-type wildcard pattern '%s'. Only '/*' supported", t))
 		}
-	} else {
-		for _, t := range defaultCompressibleContentTypes {
+		if strings.HasSuffix(t, "/*") {
+			allowedWildcards[strings.TrimSuffix(t, "/*")] = struct{}{}
+		} else {
 			allowedTypes[t] = struct{}{}
 		}
 	}

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -16,7 +16,6 @@ import (
 
 var defaultCompressibleContentTypes = []string{
 	"text/*",
-	"text/javascript",
 	"application/javascript",
 	"application/x-javascript",
 	"application/json",

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -140,7 +140,8 @@ func TestCompressorWildcards(t *testing.T) {
 	}{
 		{
 			name:       "defaults",
-			typesCount: 10,
+			typesCount: 7,
+			wcCount:    1,
 		},
 		{
 			name:       "no wildcard",


### PR DESCRIPTION
* changed the NewCompressor logic to be support wildcards in the default set like it already did for a custom list by reusing that logic
* made defaultCompressibleContentTypes contain "text/*" as all text mime types are arguably very compressible added
* application/xml to defaultCompressibleContentTypes since it is also a common XML mime type