### PR TITLE
Make Context.RoutePattern() nil-safe

### DIFF
--- a/context.go
+++ b/context.go
@@ -109,7 +109,7 @@ func (x *Context) URLParam(key string) string {
 // RoutePattern builds the routing pattern string for the particular
 // request, at the particular point during routing. This means, the value
 // will change throughout the execution of a request in a router. That is
-// why its advised to only use this value after calling the next handler.
+// why it's advised to only use this value after calling the next handler.
 //
 // For example,
 //
@@ -121,6 +121,9 @@ func (x *Context) URLParam(key string) string {
 //		})
 //	}
 func (x *Context) RoutePattern() string {
+	if x == nil {
+		return ""
+	}
 	routePattern := strings.Join(x.RoutePatterns, "")
 	routePattern = replaceWildcards(routePattern)
 	if routePattern != "/" {

--- a/context_test.go
+++ b/context_test.go
@@ -84,4 +84,10 @@ func TestRoutePattern(t *testing.T) {
 	if p := x.RoutePattern(); p != "/" {
 		t.Fatal("unexpected route pattern for root: " + p)
 	}
+
+	// Testing empty route pattern for nil context
+	var nilContext *Context
+	if p := nilContext.RoutePattern(); p != "" {
+		t.Fatalf("unexpected non-empty route pattern for nil context: %q", p)
+	}
 }


### PR DESCRIPTION
I propose to make the `Context.RoutePattern()` method nil-safe. Usage example:

```go
if routePattern := chi.RouteContext(req.Context()).RoutePattern(); routePattern != "" {
    // ...
}
```