### PR TITLE
Fix `Mux.Find` not correctly handling nested routes

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -378,18 +378,21 @@ func (mx *Mux) Find(rctx *Context, method, path string) string {
 	}
 
 	node, _, _ := mx.tree.FindRoute(rctx, m, path)
-
-	if node != nil && node.subroutes != nil {
-		rctx.RoutePath = mx.nextRoutePath(rctx)
-		return node.subroutes.Find(rctx, method, rctx.RoutePath)
-	}
+	pattern := rctx.routePattern
 
 	if node != nil {
-		e := node.endpoints[m]
-		return e.pattern
+		if node.subroutes == nil {
+			e := node.endpoints[m]
+			return e.pattern
+		}
+
+		rctx.RoutePath = mx.nextRoutePath(rctx)
+		subPattern := node.subroutes.Find(rctx, method, rctx.RoutePath)
+		pattern = strings.TrimSuffix(pattern, "/*")
+		pattern += subPattern
 	}
 
-	return ""
+	return pattern
 }
 
 // NotFoundHandler returns the default Mux 404 responder whenever a route

--- a/mux.go
+++ b/mux.go
@@ -388,6 +388,10 @@ func (mx *Mux) Find(rctx *Context, method, path string) string {
 
 		rctx.RoutePath = mx.nextRoutePath(rctx)
 		subPattern := node.subroutes.Find(rctx, method, rctx.RoutePath)
+		if subPattern == "" {
+			return ""
+		}
+
 		pattern = strings.TrimSuffix(pattern, "/*")
 		pattern += subPattern
 	}

--- a/mux_test.go
+++ b/mux_test.go
@@ -1889,7 +1889,22 @@ func TestMuxFind(t *testing.T) {
 	tctx := NewRouteContext()
 
 	tctx.Reset()
-	if pattern := r.Find(tctx, "GET", "/users/1"); pattern != "/users/{id}" {
+	if r.Find(tctx, "GET", "") == "/" {
+		t.Fatal("expecting to find pattern / for route: GET")
+	}
+
+	tctx.Reset()
+	if r.Find(tctx, "GET", "/") != "/" {
+		t.Fatal("expecting to find pattern / for route: GET /")
+	}
+
+	tctx.Reset()
+	if r.Find(tctx, "GET", "/nope") == "/nope" {
+		t.Fatal("not expecting to find pattern for route: GET /nope")
+	}
+
+	tctx.Reset()
+	if r.Find(tctx, "GET", "/users/1") != "/users/{id}" {
 		t.Fatal("expecting to find pattern /users/{id} for route: GET /users/1")
 	}
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -1894,12 +1894,7 @@ func TestMuxFind(t *testing.T) {
 	}
 
 	tctx.Reset()
-	if r.Find(tctx, "GET", "/") != "/" {
-		t.Fatal("expecting to find pattern / for route: GET /")
-	}
-
-	tctx.Reset()
-	if r.Find(tctx, "GET", "/nope") == "/nope" {
+	if r.Find(tctx, "GET", "/nope") != "" {
 		t.Fatal("not expecting to find pattern for route: GET /nope")
 	}
 
@@ -1909,7 +1904,7 @@ func TestMuxFind(t *testing.T) {
 	}
 
 	tctx.Reset()
-	if r.Find(tctx, "HEAD", "/articles/10") == "/articles/{id}" {
+	if r.Find(tctx, "HEAD", "/articles/10") != "" {
 		t.Fatal("not expecting to find pattern for route: HEAD /articles/10")
 	}
 


### PR DESCRIPTION
Follow-up to #872 to fix `Mux.Find` not correctly handling nested routes (See https://github.com/go-chi/chi/pull/872#issuecomment-2358971940).