### PR TITLE
Fixed typo in Router interface definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ type Router interface {
 	// path, with a fresh middleware stack for the inline-Router.
 	Group(fn func(r Router)) Router
 
-	// Route mounts a sub-Router along a `pattern`` string.
+	// Route mounts a sub-Router along a `pattern` string.
 	Route(pattern string, fn func(r Router)) Router
 
 	// Mount attaches another http.Handler along ./pattern/*


### PR DESCRIPTION
Fixed a typo in Router interface definition where a word `pattern`` has a extra backtick at the end.