### PR TITLE
fix(WrapResponseWriter): allow multiple informational statuses

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -81,7 +81,11 @@ type basicWriter struct {
 }
 
 func (b *basicWriter) WriteHeader(code int) {
-	if !b.wroteHeader {
+	if code >= 100 && code <= 199 && code != http.StatusSwitchingProtocols {
+		if !b.discard {
+			b.ResponseWriter.WriteHeader(code)
+		}
+	} else if !b.wroteHeader {
 		b.code = code
 		b.wroteHeader = true
 		if !b.discard {


### PR DESCRIPTION
Informational status in the range 100-199 may be sent multiple times, unlike statuses in the range 200-599.

This follows usage in the stdlib:
https://github.com/golang/go/blob/485ed2fa5b5e0b7067ef72a0f4bdc9ca12b77ed7/src/net/http/server.go#L1216

See also docs on `WriteHeader` (emphasis added):
> The provided code must be a valid HTTP 1xx-5xx status code.
> **Any number of 1xx** headers may be written, followed by **at most
> one 2xx-5xx** header. 1xx headers are sent immediately, but 2xx-5xx
> headers may be buffered. Use the Flusher interface to send
> buffered data. The header map is cleared when 2xx-5xx headers are
> sent, but not with 1xx headers.