### PR TITLE
feat: middleware.ClientIP, a replacement for middleware.RealIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ func main() {
 
   // A good base middleware stack
   r.Use(middleware.RequestID)
+  r.Use(middleware.ClientIPFromRemoteAddr) // pick one ClientIPFrom* based on your infra, see below
   r.Use(middleware.Logger)
   r.Use(middleware.Recoverer)
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ func main() {
 
   // A good base middleware stack
   r.Use(middleware.RequestID)
-  r.Use(middleware.RealIP)
   r.Use(middleware.Logger)
   r.Use(middleware.Recoverer)
 
@@ -347,7 +346,11 @@ with `net/http` can be used with chi's mux.
 | [Logger]               | Logs the start and end of each request with the elapsed processing time |
 | [NoCache]              | Sets response headers to prevent clients from caching                   |
 | [Profiler]             | Easily attach net/http/pprof to your routers                            |
-| [RealIP]               | Sets a http.Request's RemoteAddr to either X-Real-IP or X-Forwarded-For |
+| [ClientIPFromHeader]   | Capture client IP from a trusted single-IP header (X-Real-IP, CF-Connecting-IP, ...) |
+| [ClientIPFromXFF]      | Capture client IP from X-Forwarded-For, skipping listed trusted CIDR prefixes |
+| [ClientIPFromXFFTrustedProxies] | Capture client IP from X-Forwarded-For given a fixed number of trusted proxies |
+| [ClientIPFromRemoteAddr] | Capture client IP from the TCP RemoteAddr (server directly on the public internet) |
+| [RealIP]               | Deprecated — vulnerable to IP spoofing; use [ClientIPFromXFF] or another ClientIPFrom\* middleware |
 | [Recoverer]            | Gracefully absorb panics and prints the stack trace                     |
 | [RequestID]            | Injects a request ID into the context of each request                   |
 | [RedirectSlashes]      | Redirect slashes on routing paths                                       |
@@ -373,6 +376,12 @@ with `net/http` can be used with chi's mux.
 [Logger]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Logger
 [NoCache]: https://pkg.go.dev/github.com/go-chi/chi/middleware#NoCache
 [Profiler]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Profiler
+[ClientIPFromHeader]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ClientIPFromHeader
+[ClientIPFromXFF]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ClientIPFromXFF
+[ClientIPFromXFFTrustedProxies]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ClientIPFromXFFTrustedProxies
+[ClientIPFromRemoteAddr]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ClientIPFromRemoteAddr
+[GetClientIP]: https://pkg.go.dev/github.com/go-chi/chi/middleware#GetClientIP
+[GetClientIPAddr]: https://pkg.go.dev/github.com/go-chi/chi/middleware#GetClientIPAddr
 [RealIP]: https://pkg.go.dev/github.com/go-chi/chi/middleware#RealIP
 [Recoverer]: https://pkg.go.dev/github.com/go-chi/chi/middleware#Recoverer
 [RedirectSlashes]: https://pkg.go.dev/github.com/go-chi/chi/middleware#RedirectSlashes
@@ -399,6 +408,62 @@ with `net/http` can be used with chi's mux.
 [LoggerInterface]: https://pkg.go.dev/github.com/go-chi/chi/middleware#LoggerInterface
 [ThrottleOpts]: https://pkg.go.dev/github.com/go-chi/chi/middleware#ThrottleOpts
 [WrapResponseWriter]: https://pkg.go.dev/github.com/go-chi/chi/middleware#WrapResponseWriter
+
+### Choosing a ClientIP middleware
+
+The legacy [RealIP] middleware is deprecated — it is vulnerable to IP spoofing
+(GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf) and mutates
+`r.RemoteAddr`. Use one of the four `ClientIPFrom*` middlewares instead — pick
+exactly one based on your network setup — and read the resulting IP with
+[GetClientIP] (string) or [GetClientIPAddr] (`netip.Addr`):
+
+| Your setup | Use |
+|---|---|
+| Directly on the public internet, no proxy | `middleware.ClientIPFromRemoteAddr` |
+| Behind nginx (`X-Real-IP`), Cloudflare (`CF-Connecting-IP`), Apache (`X-Client-IP`) | `middleware.ClientIPFromHeader("CF-Connecting-IP")` |
+| Behind one or more proxies whose IP ranges you can list | `middleware.ClientIPFromXFF("10.0.0.0/8", ...)` |
+| Behind a known, fixed number of proxies with dynamic IPs | `middleware.ClientIPFromXFFTrustedProxies(2)` |
+
+```go
+r := chi.NewRouter()
+r.Use(middleware.RequestID)
+
+// Pick exactly one. Examples for common deployments:
+
+// Direct internet exposure (no proxy):
+// r.Use(middleware.ClientIPFromRemoteAddr)
+
+// Behind Cloudflare:
+// r.Use(middleware.ClientIPFromHeader("CF-Connecting-IP"))
+
+// Behind AWS CloudFront (or any proxy fleet with known CIDRs):
+r.Use(middleware.ClientIPFromXFF(
+    "13.32.0.0/15",   // CloudFront IPv4
+    "52.46.0.0/18",   // CloudFront IPv4
+    "2600:9000::/28", // CloudFront IPv6
+))
+
+// Behind a known number of proxies with dynamic IPs:
+// r.Use(middleware.ClientIPFromXFFTrustedProxies(2))
+
+r.Use(middleware.Logger)
+r.Use(middleware.Recoverer)
+
+r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+    clientIP := middleware.GetClientIP(r.Context()) // for logs, rate-limit keys, etc.
+    _ = clientIP
+})
+```
+
+These middlewares never mutate `r.RemoteAddr`. They store a normalized
+`netip.Addr` in the request context — IPv4-mapped IPv6 (`::ffff:a.b.c.d`)
+is folded to plain IPv4, and IPv6 zone identifiers carried in headers are
+stripped, so one logical client maps to a single canonical key for logs,
+rate limits, and ACLs.
+
+See the per-function godoc for the full semantics of each middleware, and
+[adam-p's "The perils of the 'real' client IP"](https://adam-p.ca/blog/2022/03/x-forwarded-for/)
+for the underlying threat model.
 
 ### Extra middlewares & packages
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ exactly one based on your network setup — and read the resulting IP with
 | Your setup | Use |
 |---|---|
 | Directly on the public internet, no proxy | `middleware.ClientIPFromRemoteAddr` |
-| Behind nginx (`X-Real-IP`), Cloudflare (`CF-Connecting-IP`), Apache (`X-Client-IP`) | `middleware.ClientIPFromHeader("CF-Connecting-IP")` |
+| Behind nginx (`X-Real-IP`), Cloudflare (`CF-Connecting-IP`), Apache (`X-Client-IP`) | `middleware.ClientIPFromHeader("<your-trusted-header>")` |
 | Behind one or more proxies whose IP ranges you can list | `middleware.ClientIPFromXFF("10.0.0.0/8", ...)` |
 | Behind a known, fixed number of proxies with dynamic IPs | `middleware.ClientIPFromXFFTrustedProxies(2)` |
 

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -1,0 +1,185 @@
+package middleware
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+var (
+	// clientIPCtxKey is the context key used to store the client IP address.
+	clientIPCtxKey = &contextKey{"clientIP"}
+)
+
+// ClientIPFromHeader parses the client IP address from a specified HTTP header
+// (e.g., X-Real-IP, CF-Connecting-IP) and injects it into the request context
+// if it is not already set. The parsed IP address can be retrieved using GetClientIP().
+//
+// The middleware validates the IP address to ignore loopback, private, and unspecified addresses.
+//
+// ### Important Notice:
+// - Use this middleware only when your infrastructure sets a trusted header containing the client IP.
+// - If the specified header is not securely set by your infrastructure, malicious clients could spoof it.
+//
+// Example trusted headers:
+// - "X-Real-IP"        - Nginx (ngx_http_realip_module)
+// - "X-Client-IP"      - Apache (mod_remoteip)
+// - "CF-Connecting-IP" - Cloudflare
+// - "True-Client-IP"   - Akamai, Cloudflare Enterprise
+// - "X-Azure-ClientIP" - Azure Front Door
+// - "Fastly-Client-IP" - Fastly
+func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			// Check if the client IP is already set in the context.
+			if _, ok := ctx.Value(clientIPCtxKey).(netip.Addr); ok {
+				h.ServeHTTP(w, r)
+				return
+			}
+
+			// Parse the IP address from the trusted header.
+			ip, err := netip.ParseAddr(r.Header.Get(trustedHeader))
+			if err != nil || ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() {
+				// Ignore invalid or private IPs.
+				h.ServeHTTP(w, r)
+				return
+			}
+
+			// Store the valid client IP in the context.
+			ctx = context.WithValue(ctx, clientIPCtxKey, ip)
+			h.ServeHTTP(w, r.WithContext(ctx))
+		}
+		return http.HandlerFunc(fn)
+	}
+}
+
+// ClientIPFromXFFHeader parses the client IP address from the X-Forwarded-For
+// header and injects it into the request context if it is not already set. The
+// parsed IP address can be retrieved using GetClientIP().
+//
+// The middleware traverses the X-Forwarded-For chain (rightmost untrusted IP)
+// and excludes loopback, private, unspecified, and trusted IP ranges.
+//
+// ### Important Notice:
+// - Use this middleware only when your infrastructure sets and validates the X-Forwarded-For header.
+// - Malicious clients can spoof the header unless a trusted reverse proxy or load balancer sanitizes it.
+//
+// Parameters:
+// - `trustedIPPrefixes`: A list of CIDR prefixes that define trusted proxy IP ranges.
+//
+// Example trusted IP ranges:
+// - "203.0.113.0/24"     - Example corporate proxy
+// - "198.51.100.0/24"    - Example data center or hosting provider
+// - "2400:cb00::/32"     - Cloudflare IPv6 range
+// - "2606:4700::/32"     - Cloudflare IPv6 range
+// - "192.0.2.0/24"       - Example VPN gateway
+//
+// Note: Private IP ranges (e.g., "10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12")
+// are automatically excluded by netip.Addr.IsPrivate() and do not need to be added here.
+func ClientIPFromXFFHeader(trustedIPPrefixes ...string) func(http.Handler) http.Handler {
+	// Pre-parse trusted prefixes.
+	trustedPrefixes := make([]netip.Prefix, len(trustedIPPrefixes))
+	for i, ipRange := range trustedIPPrefixes {
+		trustedPrefixes[i] = netip.MustParsePrefix(ipRange)
+	}
+
+	return func(h http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			// Check if the client IP is already set in the context.
+			if _, ok := ctx.Value(clientIPCtxKey).(netip.Addr); ok {
+				h.ServeHTTP(w, r)
+				return
+			}
+
+			// Parse and split the X-Forwarded-For header(s).
+			xff := strings.Split(strings.Join(r.Header.Values("X-Forwarded-For"), ","), ",")
+		nextValue:
+			for i := len(xff) - 1; i >= 0; i-- {
+				ip, err := netip.ParseAddr(strings.TrimSpace(xff[i]))
+				if err != nil {
+					continue
+				}
+
+				// Ignore loopback, private, or unspecified addresses.
+				if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() {
+					continue
+				}
+
+				// Ignore trusted IPs within the given ranges.
+				for _, prefix := range trustedPrefixes {
+					if prefix.Contains(ip) {
+						continue nextValue
+					}
+				}
+
+				// Store the valid client IP in the context.
+				ctx = context.WithValue(ctx, clientIPCtxKey, ip)
+				h.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
+			h.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+}
+
+// ClientIPFromRemoteAddr extracts the client IP address from the RemoteAddr
+// field of the HTTP request and injects it into the request context if it is
+// not already set. The parsed IP address can be retrieved using GetClientIP().
+//
+// The middleware ignores invalid or private IPs.
+//
+// ### Use Case:
+// This middleware is useful when the client IP cannot be determined from headers
+// such as X-Forwarded-For or X-Real-IP, and you need to fall back to RemoteAddr.
+func ClientIPFromRemoteAddr(h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// Check if the client IP is already set in the context.
+		if _, ok := ctx.Value(clientIPCtxKey).(netip.Addr); ok {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		// Extract the IP from request RemoteAddr.
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		ip, err := netip.ParseAddr(host)
+		if err != nil {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		// Store the valid client IP in the context.
+		ctx = context.WithValue(ctx, clientIPCtxKey, ip)
+		h.ServeHTTP(w, r.WithContext(ctx))
+	}
+	return http.HandlerFunc(fn)
+}
+
+// GetClientIP retrieves the client IP address from the given context.
+// The IP address is set by one of the following middlewares:
+// - ClientIPFromHeader
+// - ClientIPFromXFFHeader
+// - ClientIPFromRemoteAddr
+//
+// Returns an empty string if no valid IP is found.
+func GetClientIP(ctx context.Context) string {
+	ip, ok := ctx.Value(clientIPCtxKey).(netip.Addr)
+	if !ok || !ip.IsValid() {
+		return ""
+	}
+	return ip.String()
+}

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -119,9 +119,8 @@ func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) htt
 	}
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			xff := mergeXFF(r.Header.Values(xForwardedForHeader))
-			if i := len(xff) - numTrustedProxies; i >= 0 {
-				if ip, ok := parseHeaderAddr(xff[i]); ok {
+			if v := nthFromRightXFF(r.Header.Values(xForwardedForHeader), numTrustedProxies); v != "" {
+				if ip, ok := parseHeaderAddr(v); ok {
 					r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 				}
 			}
@@ -175,24 +174,39 @@ func GetClientIPAddr(ctx context.Context) netip.Addr {
 	return ip
 }
 
-// mergeXFF merges all X-Forwarded-For header values into a single ordered
-// list of trimmed entries (left-to-right, in the order received). Empty
-// entries are dropped. Entries are not validated as IPs here.
+// nthFromRightXFF returns the trimmed entry at position n from the right
+// end of the merged X-Forwarded-For chain (n=1 is the rightmost), or "" if
+// the chain has fewer than n non-empty entries.
 //
-// Merging all instances is required for security: per RFC 2616, multiple
-// XFF headers MUST be processed in order. Reading only the first or last
-// header value lets an attacker pick which value security logic sees by
-// sending duplicate headers.
-func mergeXFF(headers []string) []string {
-	out := make([]string, 0, len(headers))
-	for _, h := range headers {
-		for _, v := range strings.Split(h, ",") {
-			if v = strings.TrimSpace(v); v != "" {
-				out = append(out, v)
+// Empty/whitespace entries are dropped and do NOT count toward n, so an
+// attacker can't slide their chosen value into the trusted slot by
+// prepending commas.
+//
+// Multi-header merge is required for security per RFC 2616: multiple XFF
+// headers MUST be processed in order received; reading only the first or
+// last lets an attacker pick which value security logic sees by sending
+// duplicate headers. Lazy walk, zero allocations.
+func nthFromRightXFF(headers []string, n int) string {
+	for hi := len(headers) - 1; hi >= 0; hi-- {
+		h := headers[hi]
+		for h != "" {
+			var v string
+			if i := strings.LastIndexByte(h, ','); i >= 0 {
+				v, h = h[i+1:], h[:i]
+			} else {
+				v, h = h, ""
+			}
+			v = strings.TrimSpace(v)
+			if v == "" {
+				continue
+			}
+			n--
+			if n == 0 {
+				return v
 			}
 		}
 	}
-	return out
+	return ""
 }
 
 // rightmostUntrustedXFF walks all X-Forwarded-For header values right-to-left
@@ -202,10 +216,11 @@ func mergeXFF(headers []string) []string {
 // an unparseable hop is indistinguishable from a hostile or missing one and
 // we cannot safely keep walking past it.
 //
-// Walks the headers lazily rather than calling [mergeXFF] so the common case
-// — one trusted hop, the rightmost entry is the client — returns on the very
-// first iteration without materializing the full chain. Zero allocations
-// beyond what [netip.ParseAddr] does internally.
+// Walks the headers lazily so the common case — one trusted hop, rightmost
+// entry is the client — returns on the very first iteration without
+// materializing the full chain. Zero allocations beyond what
+// [netip.ParseAddr] does internally. See also [nthFromRightXFF], which uses
+// the same iteration shape with a count-down stop condition.
 func rightmostUntrustedXFF(headers []string, trustedPrefixes []netip.Prefix) (netip.Addr, bool) {
 	for hi := len(headers) - 1; hi >= 0; hi-- {
 		h := headers[hi]

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -92,8 +92,7 @@ func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handle
 // with explicit trusted CIDRs whenever you can.
 //
 // If the XFF chain has fewer than numTrustedProxies entries (header missing
-// or architecture changed), no client IP is set; chain [ClientIPFromRemoteAddr]
-// after this middleware if you want a fallback.
+// or architecture changed), no client IP is set and [GetClientIP] returns "".
 //
 // Panics at startup if numTrustedProxies < 1.
 func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) http.Handler {

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -90,7 +90,7 @@ func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handle
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var found netip.Addr
-			walkXFF(r.Header.Values(xForwardedForHeader), func(v string) bool {
+			walkXFF(r.Header[xForwardedForHeader], func(v string) bool {
 				ip, ok := parseHeaderAddr(v)
 				if !ok {
 					return true // fail-closed; leave found unset
@@ -143,7 +143,7 @@ func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) htt
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			n := numTrustedProxies
 			var entry string
-			walkXFF(r.Header.Values(xForwardedForHeader), func(v string) bool {
+			walkXFF(r.Header[xForwardedForHeader], func(v string) bool {
 				n--
 				if n == 0 {
 					entry = v

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -192,17 +192,34 @@ func mergeXFF(headers []string) []string {
 	return out
 }
 
-// rightmostUntrustedXFF walks merged XFF right-to-left, skipping IPs that
-// match trustedPrefixes (and unparseable entries), and returns the first
-// remaining valid IP.
+// rightmostUntrustedXFF walks all X-Forwarded-For header values right-to-left
+// across the merged chain, skipping IPs that match trustedPrefixes (and
+// unparseable / empty entries), and returns the first remaining valid IP.
+//
+// Walks the headers lazily rather than calling [mergeXFF] so the common case
+// — one trusted hop, the rightmost entry is the client — returns on the very
+// first iteration without materializing the full chain. Zero allocations
+// beyond what [netip.ParseAddr] does internally.
 func rightmostUntrustedXFF(headers []string, trustedPrefixes []netip.Prefix) (netip.Addr, bool) {
-	xff := mergeXFF(headers)
-	for i := len(xff) - 1; i >= 0; i-- {
-		ip, ok := parseHeaderAddr(xff[i])
-		if !ok || inAnyPrefix(ip, trustedPrefixes) {
-			continue
+	for hi := len(headers) - 1; hi >= 0; hi-- {
+		h := headers[hi]
+		for h != "" {
+			var v string
+			if i := strings.LastIndexByte(h, ','); i >= 0 {
+				v, h = h[i+1:], h[:i]
+			} else {
+				v, h = h, ""
+			}
+			v = strings.TrimSpace(v)
+			if v == "" {
+				continue
+			}
+			ip, ok := parseHeaderAddr(v)
+			if !ok || inAnyPrefix(ip, trustedPrefixes) {
+				continue
+			}
+			return ip, true
 		}
-		return ip, true
 	}
 	return netip.Addr{}, false
 }

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -8,178 +8,215 @@ import (
 	"strings"
 )
 
-var (
-	// clientIPCtxKey is the context key used to store the client IP address.
-	clientIPCtxKey = &contextKey{"clientIP"}
-)
+// clientIPCtxKey stores the client IP set by any of the ClientIPFrom* middlewares.
+var clientIPCtxKey = &contextKey{"clientIP"}
 
-// ClientIPFromHeader parses the client IP address from a specified HTTP header
-// (e.g., X-Real-IP, CF-Connecting-IP) and injects it into the request context
-// if it is not already set. The parsed IP address can be retrieved using GetClientIP().
+// ClientIPFromHeader stores the client IP read from a single-IP HTTP header
+// set by your reverse proxy. Read the IP with [GetClientIP].
 //
-// The middleware validates the IP address to ignore loopback, private, and unspecified addresses.
+// Use this when your reverse proxy sets one of these headers for every
+// request and overwrites any client-supplied value:
 //
-// ### Important Notice:
-// - Use this middleware only when your infrastructure sets a trusted header containing the client IP.
-// - If the specified header is not securely set by your infrastructure, malicious clients could spoof it.
+//   - X-Real-IP        — Nginx with ngx_http_realip_module
+//   - X-Client-IP      — Apache with mod_remoteip
+//   - CF-Connecting-IP — Cloudflare
 //
-// Example trusted headers:
-// - "X-Real-IP"        - Nginx (ngx_http_realip_module)
-// - "X-Client-IP"      - Apache (mod_remoteip)
-// - "CF-Connecting-IP" - Cloudflare
-// - "True-Client-IP"   - Akamai, Cloudflare Enterprise
-// - "X-Azure-ClientIP" - Azure Front Door
-// - "Fastly-Client-IP" - Fastly
+// DO NOT use this with headers your infrastructure does not overwrite
+// (True-Client-IP, X-Azure-ClientIP, Fastly-Client-IP by default, etc.).
+// Those can be supplied by the client and are trivially spoofable.
 func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
-		fn := func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-
-			// Check if the client IP is already set in the context.
-			if _, ok := ctx.Value(clientIPCtxKey).(netip.Addr); ok {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if hasClientIP(r.Context()) {
 				h.ServeHTTP(w, r)
 				return
 			}
-
-			// Parse the IP address from the trusted header.
-			ip, err := netip.ParseAddr(r.Header.Get(trustedHeader))
-			if err != nil || ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() {
-				// Ignore invalid or private IPs.
-				h.ServeHTTP(w, r)
-				return
+			if ip, err := netip.ParseAddr(r.Header.Get(trustedHeader)); err == nil {
+				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 			}
-
-			// Store the valid client IP in the context.
-			ctx = context.WithValue(ctx, clientIPCtxKey, ip)
-			h.ServeHTTP(w, r.WithContext(ctx))
-		}
-		return http.HandlerFunc(fn)
-	}
-}
-
-// ClientIPFromXFFHeader parses the client IP address from the X-Forwarded-For
-// header and injects it into the request context if it is not already set. The
-// parsed IP address can be retrieved using GetClientIP().
-//
-// The middleware traverses the X-Forwarded-For chain (rightmost untrusted IP)
-// and excludes loopback, private, unspecified, and trusted IP ranges.
-//
-// ### Important Notice:
-// - Use this middleware only when your infrastructure sets and validates the X-Forwarded-For header.
-// - Malicious clients can spoof the header unless a trusted reverse proxy or load balancer sanitizes it.
-//
-// Parameters:
-// - `trustedIPPrefixes`: A list of CIDR prefixes that define trusted proxy IP ranges.
-//
-// Example trusted IP ranges:
-// - "203.0.113.0/24"     - Example corporate proxy
-// - "198.51.100.0/24"    - Example data center or hosting provider
-// - "2400:cb00::/32"     - Cloudflare IPv6 range
-// - "2606:4700::/32"     - Cloudflare IPv6 range
-// - "192.0.2.0/24"       - Example VPN gateway
-//
-// Note: Private IP ranges (e.g., "10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12")
-// are automatically excluded by netip.Addr.IsPrivate() and do not need to be added here.
-func ClientIPFromXFFHeader(trustedIPPrefixes ...string) func(http.Handler) http.Handler {
-	// Pre-parse trusted prefixes.
-	trustedPrefixes := make([]netip.Prefix, len(trustedIPPrefixes))
-	for i, ipRange := range trustedIPPrefixes {
-		trustedPrefixes[i] = netip.MustParsePrefix(ipRange)
-	}
-
-	return func(h http.Handler) http.Handler {
-		fn := func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-
-			// Check if the client IP is already set in the context.
-			if _, ok := ctx.Value(clientIPCtxKey).(netip.Addr); ok {
-				h.ServeHTTP(w, r)
-				return
-			}
-
-			// Parse and split the X-Forwarded-For header(s).
-			xff := strings.Split(strings.Join(r.Header.Values("X-Forwarded-For"), ","), ",")
-		nextValue:
-			for i := len(xff) - 1; i >= 0; i-- {
-				ip, err := netip.ParseAddr(strings.TrimSpace(xff[i]))
-				if err != nil {
-					continue
-				}
-
-				// Ignore loopback, private, or unspecified addresses.
-				if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() {
-					continue
-				}
-
-				// Ignore trusted IPs within the given ranges.
-				for _, prefix := range trustedPrefixes {
-					if prefix.Contains(ip) {
-						continue nextValue
-					}
-				}
-
-				// Store the valid client IP in the context.
-				ctx = context.WithValue(ctx, clientIPCtxKey, ip)
-				h.ServeHTTP(w, r.WithContext(ctx))
-				return
-			}
-
 			h.ServeHTTP(w, r)
-		}
-		return http.HandlerFunc(fn)
+		})
 	}
 }
 
-// ClientIPFromRemoteAddr extracts the client IP address from the RemoteAddr
-// field of the HTTP request and injects it into the request context if it is
-// not already set. The parsed IP address can be retrieved using GetClientIP().
+// ClientIPFromXFF stores the client IP read from the X-Forwarded-For header,
+// walking the chain right-to-left and skipping any IP that falls within one
+// of the given trusted CIDR prefixes. The first IP that is not trusted is
+// the client. Read it with [GetClientIP].
 //
-// The middleware ignores invalid or private IPs.
+// Use this when you sit behind one or more reverse proxies whose IP ranges
+// you can enumerate as CIDRs:
 //
-// ### Use Case:
-// This middleware is useful when the client IP cannot be determined from headers
-// such as X-Forwarded-For or X-Real-IP, and you need to fall back to RemoteAddr.
-func ClientIPFromRemoteAddr(h http.Handler) http.Handler {
-	fn := func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+//	r.Use(middleware.ClientIPFromXFF(
+//	    "13.32.0.0/15",   // CloudFront IPv4
+//	    "52.46.0.0/18",   // CloudFront IPv4
+//	    "2600:9000::/28", // CloudFront IPv6
+//	))
+//
+// Calling with no arguments returns the rightmost parseable XFF IP — safe
+// only if you have exactly one trusted hop directly in front of this server
+// (e.g., nginx on localhost).
+//
+// If you know the number of trusted proxies but not their IPs, use
+// [ClientIPFromXFFTrustedProxies] instead.
+//
+// Panics at startup if any prefix is invalid.
+func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handler {
+	prefixes := make([]netip.Prefix, len(trustedIPPrefixes))
+	for i, p := range trustedIPPrefixes {
+		prefixes[i] = netip.MustParsePrefix(p)
+	}
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if hasClientIP(r.Context()) {
+				h.ServeHTTP(w, r)
+				return
+			}
+			if ip, ok := rightmostUntrustedXFF(r.Header.Values("X-Forwarded-For"), prefixes); ok {
+				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
+			}
+			h.ServeHTTP(w, r)
+		})
+	}
+}
 
-		// Check if the client IP is already set in the context.
-		if _, ok := ctx.Value(clientIPCtxKey).(netip.Addr); ok {
+// ClientIPFromXFFTrustedProxies stores the client IP read from the
+// X-Forwarded-For header, given the exact number of trusted reverse proxies
+// between this server and the public internet. It returns the IP at position
+// len(xff) - numTrustedProxies in the merged X-Forwarded-For list — the IP
+// added by the outermost of your trusted proxies, the only IP in the chain
+// that none of your proxies have allowed an attacker to forge. Read it with
+// [GetClientIP].
+//
+// Use this when:
+//   - You know exactly how many proxies you sit behind, AND
+//   - Their IP addresses are dynamic (autoscaling proxy pools, ephemeral
+//     containers, dynamic CDN edges) so listing CIDRs with [ClientIPFromXFF]
+//     is impractical.
+//
+// WARNING: This variant is brittle to network architecture changes. If you
+// add or remove a proxy level, numTrustedProxies silently becomes wrong and
+// you may start trusting an attacker-supplied IP. Prefer [ClientIPFromXFF]
+// with explicit trusted CIDRs whenever you can.
+//
+// If the XFF chain has fewer than numTrustedProxies entries (header missing
+// or architecture changed), no client IP is set; chain [ClientIPFromRemoteAddr]
+// after this middleware if you want a fallback.
+//
+// Panics at startup if numTrustedProxies < 1.
+func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) http.Handler {
+	if numTrustedProxies < 1 {
+		panic("middleware.ClientIPFromXFFTrustedProxies: numTrustedProxies must be >= 1")
+	}
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if hasClientIP(r.Context()) {
+				h.ServeHTTP(w, r)
+				return
+			}
+			xff := mergeXFF(r.Header.Values("X-Forwarded-For"))
+			if i := len(xff) - numTrustedProxies; i >= 0 {
+				if ip, err := netip.ParseAddr(xff[i]); err == nil {
+					r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
+				}
+			}
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+// ClientIPFromRemoteAddr stores the client IP read from the TCP RemoteAddr
+// of the incoming request — the IP address of whoever opened the connection
+// to this server. Read it with [GetClientIP].
+//
+// Use this when this server is directly connected to the public internet
+// with NO reverse proxy in front of it. Behind a reverse proxy, RemoteAddr
+// is the proxy's IP, not the client's — use [ClientIPFromHeader] or
+// [ClientIPFromXFF] instead.
+func ClientIPFromRemoteAddr(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hasClientIP(r.Context()) {
 			h.ServeHTTP(w, r)
 			return
 		}
-
-		// Extract the IP from request RemoteAddr.
 		host, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
-			h.ServeHTTP(w, r)
-			return
+			host = r.RemoteAddr // RemoteAddr may already be a bare IP (e.g. in tests).
 		}
-
-		ip, err := netip.ParseAddr(host)
-		if err != nil {
-			h.ServeHTTP(w, r)
-			return
+		if ip, err := netip.ParseAddr(host); err == nil {
+			r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 		}
-
-		// Store the valid client IP in the context.
-		ctx = context.WithValue(ctx, clientIPCtxKey, ip)
-		h.ServeHTTP(w, r.WithContext(ctx))
-	}
-	return http.HandlerFunc(fn)
+		h.ServeHTTP(w, r)
+	})
 }
 
-// GetClientIP retrieves the client IP address from the given context.
-// The IP address is set by one of the following middlewares:
-// - ClientIPFromHeader
-// - ClientIPFromXFFHeader
-// - ClientIPFromRemoteAddr
-//
-// Returns an empty string if no valid IP is found.
+// GetClientIP returns the client IP as a string, as set by one of the
+// ClientIPFrom* middlewares. Returns "" if no valid IP was set.
+// Convenient for logging, rate-limit keys, etc.
 func GetClientIP(ctx context.Context) string {
-	ip, ok := ctx.Value(clientIPCtxKey).(netip.Addr)
-	if !ok || !ip.IsValid() {
+	ip := GetClientIPAddr(ctx)
+	if !ip.IsValid() {
 		return ""
 	}
 	return ip.String()
+}
+
+// GetClientIPAddr returns the client IP as a [netip.Addr], as set by one of
+// the ClientIPFrom* middlewares. The returned Addr is the zero value if not
+// set; use [netip.Addr.IsValid] to check. Useful when you need typed work —
+// prefix containment, Is4/Is6, etc. — without re-parsing the string.
+func GetClientIPAddr(ctx context.Context) netip.Addr {
+	ip, _ := ctx.Value(clientIPCtxKey).(netip.Addr)
+	return ip
+}
+
+// hasClientIP reports whether an upstream ClientIPFrom* middleware has
+// already set a valid client IP on the context.
+func hasClientIP(ctx context.Context) bool {
+	return GetClientIPAddr(ctx).IsValid()
+}
+
+// mergeXFF merges all X-Forwarded-For header values into a single ordered
+// list of trimmed entries (left-to-right, in the order received). Empty
+// entries are dropped. Entries are not validated as IPs here.
+//
+// Merging all instances is required for security: per RFC 2616, multiple
+// XFF headers MUST be processed in order. Reading only the first or last
+// header value lets an attacker pick which value security logic sees by
+// sending duplicate headers.
+func mergeXFF(headers []string) []string {
+	out := make([]string, 0, len(headers))
+	for _, h := range headers {
+		for _, v := range strings.Split(h, ",") {
+			if v = strings.TrimSpace(v); v != "" {
+				out = append(out, v)
+			}
+		}
+	}
+	return out
+}
+
+// rightmostUntrustedXFF walks merged XFF right-to-left, skipping IPs that
+// match trustedPrefixes (and unparseable entries), and returns the first
+// remaining valid IP.
+func rightmostUntrustedXFF(headers []string, trustedPrefixes []netip.Prefix) (netip.Addr, bool) {
+	xff := mergeXFF(headers)
+	for i := len(xff) - 1; i >= 0; i-- {
+		ip, err := netip.ParseAddr(xff[i])
+		if err != nil || inAnyPrefix(ip, trustedPrefixes) {
+			continue
+		}
+		return ip, true
+	}
+	return netip.Addr{}, false
+}
+
+// inAnyPrefix reports whether ip falls within any of the given prefixes.
+func inAnyPrefix(ip netip.Addr, prefixes []netip.Prefix) bool {
+	for _, p := range prefixes {
+		if p.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -15,24 +15,22 @@ var clientIPCtxKey = &contextKey{"clientIP"}
 // name, used by the XFF-based middlewares.
 const xForwardedForHeader = "X-Forwarded-For"
 
-// ClientIPFromHeader stores the client IP read from a single-IP HTTP header
-// set by your reverse proxy. Read the IP with [GetClientIP].
+// ClientIPFromHeader stores the client IP from a single-IP header set by
+// your reverse proxy. Read it with [GetClientIP].
 //
-// Use this when your reverse proxy sets one of these headers for every
-// request and overwrites any client-supplied value:
+// Only safe with headers your proxy unconditionally OVERWRITES on every
+// request, e.g.:
 //
 //   - X-Real-IP        — Nginx with ngx_http_realip_module
 //   - X-Client-IP      — Apache with mod_remoteip
 //   - CF-Connecting-IP — Cloudflare
 //
-// DO NOT use this with headers your infrastructure does not overwrite
-// (True-Client-IP, X-Azure-ClientIP, Fastly-Client-IP by default, etc.).
-// Those can be supplied by the client and are trivially spoofable.
+// True-Client-IP, X-Azure-ClientIP, and Fastly-Client-IP look similar but
+// pass through from the client by default in those products; don't use them
+// unless your edge strips the inbound value.
 //
-// IPv4 addresses written in IPv4-mapped IPv6 notation (::ffff:a.b.c.d) are
-// folded to their plain IPv4 form, and any IPv6 zone identifier is stripped,
-// so the stored value is a single canonical form regardless of how the
-// upstream proxy chose to encode it.
+// v4-mapped IPv6 (::ffff:a.b.c.d) folds to plain v4 and IPv6 zones are
+// stripped before storage.
 func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
 	header := http.CanonicalHeaderKey(trustedHeader)
 	return func(h http.Handler) http.Handler {
@@ -63,10 +61,9 @@ func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
 // only if you have exactly one trusted hop directly in front of this server
 // (e.g., nginx on localhost).
 //
-// IPv4 addresses written in IPv4-mapped IPv6 notation (::ffff:a.b.c.d) are
-// folded to their plain IPv4 form, and any IPv6 zone identifier is stripped,
-// before the prefix check and storage — both notations are otherwise
-// attacker-controllable aliases that escape a naive prefix match.
+// v4-mapped IPv6 (::ffff:a.b.c.d) folds to plain v4 and IPv6 zones are
+// stripped before the prefix check and storage; otherwise an attacker
+// could use either notation to alias a trusted IP past the check.
 //
 // If you know the number of trusted proxies but not their IPs, use
 // [ClientIPFromXFFTrustedProxies] instead.
@@ -109,10 +106,8 @@ func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handle
 // If the XFF chain has fewer than numTrustedProxies entries (header missing
 // or architecture changed), no client IP is set and [GetClientIP] returns "".
 //
-// As with [ClientIPFromXFF], an IPv4-mapped IPv6 entry at the chosen slot is
-// folded to its plain IPv4 form and any IPv6 zone identifier is stripped, so
-// the stored value is a single canonical form regardless of how the upstream
-// proxy chose to encode it.
+// Like [ClientIPFromXFF], v4-mapped IPv6 folds to plain v4 and IPv6 zones
+// are stripped before storage.
 //
 // Panics at startup if numTrustedProxies < 1.
 func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) http.Handler {
@@ -141,11 +136,9 @@ func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) htt
 // is the proxy's IP, not the client's — use [ClientIPFromHeader] or
 // [ClientIPFromXFF] instead.
 //
-// IPv4 clients accepted on a dual-stack listener surface as IPv4-mapped IPv6
-// (::ffff:a.b.c.d); they are folded to plain IPv4 before storage so one
-// logical client maps to one rate-limit key / log entry regardless of how
-// the listener is configured. Any IPv6 zone identifier is preserved (it may
-// legitimately be set for link-local connections).
+// IPv4 clients on a dual-stack listener surface as ::ffff:a.b.c.d; they
+// fold to plain v4 before storage so one logical client maps to one key.
+// IPv6 zones are preserved (link-local connections may legitimately have one).
 func ClientIPFromRemoteAddr(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host, _, err := net.SplitHostPort(r.RemoteAddr)
@@ -224,22 +217,15 @@ func inAnyPrefix(ip netip.Addr, prefixes []netip.Prefix) bool {
 	return false
 }
 
-// parseHeaderAddr parses s as a [netip.Addr] and normalizes it to its
-// canonical wire form: IPv4-mapped IPv6 (::ffff:a.b.c.d) is folded to plain
-// IPv4, and any IPv6 zone identifier is stripped.
+// parseHeaderAddr parses s and normalizes for storage: v4-mapped IPv6
+// (::ffff:a.b.c.d) folds to plain v4, IPv6 zone is stripped. Both defend the
+// trust-prefix check against attacker-injected aliases — [netip.Prefix.Contains]
+// returns false for v4-mapped addresses vs v4 prefixes and for any zoned
+// address, so without folding/stripping an attacker could escape an
+// otherwise valid trust list.
 //
-// Both normalizations defend the trust-prefix check (and downstream rate-
-// limit keys, log keys, and ACLs) against attacker-injected aliases of
-// trusted addresses: [netip.Prefix.Contains] returns false for v4-mapped
-// addresses checked against IPv4 prefixes, and false for any zoned address,
-// so without folding/stripping an attacker could escape an otherwise valid
-// trust list. Zone identifiers carry no meaning on the wire; v4-mapped
-// notation is just an alternate spelling of the same IPv4 address.
-//
-// Used for IPs that arrive via HTTP headers (XFF, single-IP trusted header).
-// [ClientIPFromRemoteAddr] normalizes separately: it Unmaps the address but
-// preserves the zone, because RemoteAddr can legitimately be a link-local
-// IPv6 address with a meaningful zone identifier.
+// Header-sourced IPs only. [ClientIPFromRemoteAddr] normalizes inline
+// (Unmap, but zone preserved for legitimate link-local connections).
 func parseHeaderAddr(s string) (netip.Addr, bool) {
 	ip, err := netip.ParseAddr(s)
 	if err != nil {

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -79,8 +79,20 @@ func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handle
 	}
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if ip, ok := rightmostUntrustedXFF(r.Header.Values(xForwardedForHeader), prefixes); ok {
-				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
+			var found netip.Addr
+			walkXFF(r.Header.Values(xForwardedForHeader), func(v string) bool {
+				ip, ok := parseHeaderAddr(v)
+				if !ok {
+					return true // fail-closed; leave found unset
+				}
+				if inAnyPrefix(ip, prefixes) {
+					return false // trusted hop; keep walking left
+				}
+				found = ip
+				return true
+			})
+			if found.IsValid() {
+				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, found))
 			}
 			h.ServeHTTP(w, r)
 		})
@@ -119,8 +131,18 @@ func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) htt
 	}
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if v := nthFromRightXFF(r.Header.Values(xForwardedForHeader), numTrustedProxies); v != "" {
-				if ip, ok := parseHeaderAddr(v); ok {
+			n := numTrustedProxies
+			var entry string
+			walkXFF(r.Header.Values(xForwardedForHeader), func(v string) bool {
+				n--
+				if n == 0 {
+					entry = v
+					return true
+				}
+				return false
+			})
+			if entry != "" {
+				if ip, ok := parseHeaderAddr(entry); ok {
 					r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 				}
 			}
@@ -174,19 +196,15 @@ func GetClientIPAddr(ctx context.Context) netip.Addr {
 	return ip
 }
 
-// nthFromRightXFF returns the trimmed entry at position n from the right
-// end of the merged X-Forwarded-For chain (n=1 is the rightmost), or "" if
-// the chain has fewer than n non-empty entries.
+// walkXFF walks the entries of the merged X-Forwarded-For chain
+// RIGHT-TO-LEFT, invoking visit on each trimmed non-empty entry. visit
+// returns true to stop the walk. Lazy walk, zero allocations (entries
+// are substrings of the input headers).
 //
-// Empty/whitespace entries are dropped and do NOT count toward n, so an
-// attacker can't slide their chosen value into the trusted slot by
-// prepending commas.
-//
-// Multi-header merge is required for security per RFC 2616: multiple XFF
-// headers MUST be processed in order received; reading only the first or
-// last lets an attacker pick which value security logic sees by sending
-// duplicate headers. Lazy walk, zero allocations.
-func nthFromRightXFF(headers []string, n int) string {
+// Multiple XFF headers are merged per RFC 2616 — each header's
+// comma-separated entries in order received — so an attacker cannot pick
+// which value security logic sees by sending a duplicate header.
+func walkXFF(headers []string, visit func(entry string) bool) {
 	for hi := len(headers) - 1; hi >= 0; hi-- {
 		h := headers[hi]
 		for h != "" {
@@ -200,52 +218,11 @@ func nthFromRightXFF(headers []string, n int) string {
 			if v == "" {
 				continue
 			}
-			n--
-			if n == 0 {
-				return v
+			if visit(v) {
+				return
 			}
 		}
 	}
-	return ""
-}
-
-// rightmostUntrustedXFF walks all X-Forwarded-For header values right-to-left
-// across the merged chain, skipping trusted-prefix and empty entries, and
-// returns the first remaining valid IP. An unparseable entry encountered
-// mid-walk fails closed: the walk is abandoned and no IP is returned, since
-// an unparseable hop is indistinguishable from a hostile or missing one and
-// we cannot safely keep walking past it.
-//
-// Walks the headers lazily so the common case — one trusted hop, rightmost
-// entry is the client — returns on the very first iteration without
-// materializing the full chain. Zero allocations beyond what
-// [netip.ParseAddr] does internally. See also [nthFromRightXFF], which uses
-// the same iteration shape with a count-down stop condition.
-func rightmostUntrustedXFF(headers []string, trustedPrefixes []netip.Prefix) (netip.Addr, bool) {
-	for hi := len(headers) - 1; hi >= 0; hi-- {
-		h := headers[hi]
-		for h != "" {
-			var v string
-			if i := strings.LastIndexByte(h, ','); i >= 0 {
-				v, h = h[i+1:], h[:i]
-			} else {
-				v, h = h, ""
-			}
-			v = strings.TrimSpace(v)
-			if v == "" {
-				continue
-			}
-			ip, ok := parseHeaderAddr(v)
-			if !ok {
-				return netip.Addr{}, false
-			}
-			if inAnyPrefix(ip, trustedPrefixes) {
-				continue
-			}
-			return ip, true
-		}
-	}
-	return netip.Addr{}, false
 }
 
 // inAnyPrefix reports whether ip falls within any of the given prefixes.

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -11,6 +11,10 @@ import (
 // clientIPCtxKey stores the client IP set by any of the ClientIPFrom* middlewares.
 var clientIPCtxKey = &contextKey{"clientIP"}
 
+// xForwardedForHeader is the canonical form of the X-Forwarded-For header
+// name, used by the XFF-based middlewares.
+const xForwardedForHeader = "X-Forwarded-For"
+
 // ClientIPFromHeader stores the client IP read from a single-IP HTTP header
 // set by your reverse proxy. Read the IP with [GetClientIP].
 //
@@ -24,10 +28,16 @@ var clientIPCtxKey = &contextKey{"clientIP"}
 // DO NOT use this with headers your infrastructure does not overwrite
 // (True-Client-IP, X-Azure-ClientIP, Fastly-Client-IP by default, etc.).
 // Those can be supplied by the client and are trivially spoofable.
+//
+// IPv4 addresses written in IPv4-mapped IPv6 notation (::ffff:a.b.c.d) are
+// folded to their plain IPv4 form, and any IPv6 zone identifier is stripped,
+// so the stored value is a single canonical form regardless of how the
+// upstream proxy chose to encode it.
 func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
+	header := http.CanonicalHeaderKey(trustedHeader)
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if ip, err := netip.ParseAddr(r.Header.Get(trustedHeader)); err == nil {
+			if ip, ok := parseHeaderAddr(r.Header.Get(header)); ok {
 				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 			}
 			h.ServeHTTP(w, r)
@@ -53,6 +63,11 @@ func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
 // only if you have exactly one trusted hop directly in front of this server
 // (e.g., nginx on localhost).
 //
+// IPv4 addresses written in IPv4-mapped IPv6 notation (::ffff:a.b.c.d) are
+// folded to their plain IPv4 form, and any IPv6 zone identifier is stripped,
+// before the prefix check and storage — both notations are otherwise
+// attacker-controllable aliases that escape a naive prefix match.
+//
 // If you know the number of trusted proxies but not their IPs, use
 // [ClientIPFromXFFTrustedProxies] instead.
 //
@@ -64,7 +79,7 @@ func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handle
 	}
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if ip, ok := rightmostUntrustedXFF(r.Header.Values("X-Forwarded-For"), prefixes); ok {
+			if ip, ok := rightmostUntrustedXFF(r.Header.Values(xForwardedForHeader), prefixes); ok {
 				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 			}
 			h.ServeHTTP(w, r)
@@ -94,6 +109,11 @@ func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handle
 // If the XFF chain has fewer than numTrustedProxies entries (header missing
 // or architecture changed), no client IP is set and [GetClientIP] returns "".
 //
+// As with [ClientIPFromXFF], an IPv4-mapped IPv6 entry at the chosen slot is
+// folded to its plain IPv4 form and any IPv6 zone identifier is stripped, so
+// the stored value is a single canonical form regardless of how the upstream
+// proxy chose to encode it.
+//
 // Panics at startup if numTrustedProxies < 1.
 func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) http.Handler {
 	if numTrustedProxies < 1 {
@@ -101,9 +121,9 @@ func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) htt
 	}
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			xff := mergeXFF(r.Header.Values("X-Forwarded-For"))
+			xff := mergeXFF(r.Header.Values(xForwardedForHeader))
 			if i := len(xff) - numTrustedProxies; i >= 0 {
-				if ip, err := netip.ParseAddr(xff[i]); err == nil {
+				if ip, ok := parseHeaderAddr(xff[i]); ok {
 					r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 				}
 			}
@@ -120,6 +140,12 @@ func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) htt
 // with NO reverse proxy in front of it. Behind a reverse proxy, RemoteAddr
 // is the proxy's IP, not the client's — use [ClientIPFromHeader] or
 // [ClientIPFromXFF] instead.
+//
+// IPv4 clients accepted on a dual-stack listener surface as IPv4-mapped IPv6
+// (::ffff:a.b.c.d); they are folded to plain IPv4 before storage so one
+// logical client maps to one rate-limit key / log entry regardless of how
+// the listener is configured. Any IPv6 zone identifier is preserved (it may
+// legitimately be set for link-local connections).
 func ClientIPFromRemoteAddr(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host, _, err := net.SplitHostPort(r.RemoteAddr)
@@ -127,7 +153,7 @@ func ClientIPFromRemoteAddr(h http.Handler) http.Handler {
 			host = r.RemoteAddr // RemoteAddr may already be a bare IP (e.g. in tests).
 		}
 		if ip, err := netip.ParseAddr(host); err == nil {
-			r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
+			r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip.Unmap()))
 		}
 		h.ServeHTTP(w, r)
 	})
@@ -179,8 +205,8 @@ func mergeXFF(headers []string) []string {
 func rightmostUntrustedXFF(headers []string, trustedPrefixes []netip.Prefix) (netip.Addr, bool) {
 	xff := mergeXFF(headers)
 	for i := len(xff) - 1; i >= 0; i-- {
-		ip, err := netip.ParseAddr(xff[i])
-		if err != nil || inAnyPrefix(ip, trustedPrefixes) {
+		ip, ok := parseHeaderAddr(xff[i])
+		if !ok || inAnyPrefix(ip, trustedPrefixes) {
 			continue
 		}
 		return ip, true
@@ -196,4 +222,28 @@ func inAnyPrefix(ip netip.Addr, prefixes []netip.Prefix) bool {
 		}
 	}
 	return false
+}
+
+// parseHeaderAddr parses s as a [netip.Addr] and normalizes it to its
+// canonical wire form: IPv4-mapped IPv6 (::ffff:a.b.c.d) is folded to plain
+// IPv4, and any IPv6 zone identifier is stripped.
+//
+// Both normalizations defend the trust-prefix check (and downstream rate-
+// limit keys, log keys, and ACLs) against attacker-injected aliases of
+// trusted addresses: [netip.Prefix.Contains] returns false for v4-mapped
+// addresses checked against IPv4 prefixes, and false for any zoned address,
+// so without folding/stripping an attacker could escape an otherwise valid
+// trust list. Zone identifiers carry no meaning on the wire; v4-mapped
+// notation is just an alternate spelling of the same IPv4 address.
+//
+// Used for IPs that arrive via HTTP headers (XFF, single-IP trusted header).
+// [ClientIPFromRemoteAddr] normalizes separately: it Unmaps the address but
+// preserves the zone, because RemoteAddr can legitimately be a link-local
+// IPv6 address with a meaningful zone identifier.
+func parseHeaderAddr(s string) (netip.Addr, bool) {
+	ip, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return ip.Unmap().WithZone(""), true
 }

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -48,6 +48,9 @@ func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
 // of the given trusted CIDR prefixes. The first IP that is not trusted is
 // the client. Read it with [GetClientIP].
 //
+// An unparseable entry mid-chain aborts the walk and leaves no client IP
+// set (fail-closed) — we can't safely trust anything left of garbage.
+//
 // Use this when you sit behind one or more reverse proxies whose IP ranges
 // you can enumerate as CIDRs:
 //
@@ -193,8 +196,11 @@ func mergeXFF(headers []string) []string {
 }
 
 // rightmostUntrustedXFF walks all X-Forwarded-For header values right-to-left
-// across the merged chain, skipping IPs that match trustedPrefixes (and
-// unparseable / empty entries), and returns the first remaining valid IP.
+// across the merged chain, skipping trusted-prefix and empty entries, and
+// returns the first remaining valid IP. An unparseable entry encountered
+// mid-walk fails closed: the walk is abandoned and no IP is returned, since
+// an unparseable hop is indistinguishable from a hostile or missing one and
+// we cannot safely keep walking past it.
 //
 // Walks the headers lazily rather than calling [mergeXFF] so the common case
 // — one trusted hop, the rightmost entry is the client — returns on the very
@@ -215,7 +221,10 @@ func rightmostUntrustedXFF(headers []string, trustedPrefixes []netip.Prefix) (ne
 				continue
 			}
 			ip, ok := parseHeaderAddr(v)
-			if !ok || inAnyPrefix(ip, trustedPrefixes) {
+			if !ok {
+				return netip.Addr{}, false
+			}
+			if inAnyPrefix(ip, trustedPrefixes) {
 				continue
 			}
 			return ip, true

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -27,10 +27,6 @@ var clientIPCtxKey = &contextKey{"clientIP"}
 func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if hasClientIP(r.Context()) {
-				h.ServeHTTP(w, r)
-				return
-			}
 			if ip, err := netip.ParseAddr(r.Header.Get(trustedHeader)); err == nil {
 				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 			}
@@ -68,10 +64,6 @@ func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handle
 	}
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if hasClientIP(r.Context()) {
-				h.ServeHTTP(w, r)
-				return
-			}
 			if ip, ok := rightmostUntrustedXFF(r.Header.Values("X-Forwarded-For"), prefixes); ok {
 				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
 			}
@@ -110,10 +102,6 @@ func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) htt
 	}
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if hasClientIP(r.Context()) {
-				h.ServeHTTP(w, r)
-				return
-			}
 			xff := mergeXFF(r.Header.Values("X-Forwarded-For"))
 			if i := len(xff) - numTrustedProxies; i >= 0 {
 				if ip, err := netip.ParseAddr(xff[i]); err == nil {
@@ -135,10 +123,6 @@ func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) htt
 // [ClientIPFromXFF] instead.
 func ClientIPFromRemoteAddr(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if hasClientIP(r.Context()) {
-			h.ServeHTTP(w, r)
-			return
-		}
 		host, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
 			host = r.RemoteAddr // RemoteAddr may already be a bare IP (e.g. in tests).
@@ -168,12 +152,6 @@ func GetClientIP(ctx context.Context) string {
 func GetClientIPAddr(ctx context.Context) netip.Addr {
 	ip, _ := ctx.Value(clientIPCtxKey).(netip.Addr)
 	return ip
-}
-
-// hasClientIP reports whether an upstream ClientIPFrom* middleware has
-// already set a valid client IP on the context.
-func hasClientIP(ctx context.Context) bool {
-	return GetClientIPAddr(ctx).IsValid()
 }
 
 // mergeXFF merges all X-Forwarded-For header values into a single ordered

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -70,9 +70,9 @@ func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
 //	    "2600:9000::/28", // CloudFront IPv6
 //	))
 //
-// Calling with no arguments returns the rightmost parseable XFF IP — safe
-// only if you have exactly one trusted hop directly in front of this server
-// (e.g., nginx on localhost).
+// Calling with no arguments returns the rightmost XFF entry, or no IP if
+// that entry doesn't parse (fail-closed) — safe only if you have exactly
+// one trusted hop directly in front of this server (e.g., nginx on localhost).
 //
 // v4-mapped IPv6 (::ffff:a.b.c.d) folds to plain v4 and IPv6 zones are
 // stripped before the prefix check and storage; otherwise an attacker

--- a/middleware/client_ip.go
+++ b/middleware/client_ip.go
@@ -29,14 +29,24 @@ const xForwardedForHeader = "X-Forwarded-For"
 // pass through from the client by default in those products; don't use them
 // unless your edge strips the inbound value.
 //
+// If the header reaches us with multiple values (misconfigured proxy that
+// appends, or a downstream proxy not stripping a client-supplied value),
+// the LAST value wins — that's the one set by the hop closest to us, and
+// therefore the most trusted. Fail-closed if the last value doesn't parse:
+// no client IP is set rather than falling back to earlier (less-trusted)
+// values.
+//
 // v4-mapped IPv6 (::ffff:a.b.c.d) folds to plain v4 and IPv6 zones are
 // stripped before storage.
 func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler {
 	header := http.CanonicalHeaderKey(trustedHeader)
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if ip, ok := parseHeaderAddr(r.Header.Get(header)); ok {
-				r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
+			values := r.Header.Values(header)
+			if len(values) > 0 {
+				if ip, ok := parseHeaderAddr(values[len(values)-1]); ok {
+					r = r.WithContext(context.WithValue(r.Context(), clientIPCtxKey, ip))
+				}
 			}
 			h.ServeHTTP(w, r)
 		})

--- a/middleware/client_ip_bench_test.go
+++ b/middleware/client_ip_bench_test.go
@@ -8,8 +8,8 @@ import (
 
 // BenchmarkWalkXFF measures the cost of walking a merged X-Forwarded-For
 // chain end-to-end (visitor never stops). Exercises the worst case for
-// rightmostUntrustedXFF when every entry is in the trusted prefix list,
-// and bounds the absolute cost of a pathologically large attacker-supplied
+// ClientIPFromXFF when every entry is in the trusted prefix list, and
+// bounds the absolute cost of a pathologically large attacker-supplied
 // XFF header (subject to http.Server.MaxHeaderBytes).
 //
 // n varies the number of comma-separated entries in a single XFF header.

--- a/middleware/client_ip_bench_test.go
+++ b/middleware/client_ip_bench_test.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// BenchmarkWalkXFF measures the cost of walking a merged X-Forwarded-For
+// chain end-to-end (visitor never stops). Exercises the worst case for
+// rightmostUntrustedXFF when every entry is in the trusted prefix list,
+// and bounds the absolute cost of a pathologically large attacker-supplied
+// XFF header (subject to http.Server.MaxHeaderBytes).
+//
+// n varies the number of comma-separated entries in a single XFF header.
+// All entries are valid IPs of identical length, so total header size
+// scales linearly with n.
+func BenchmarkWalkXFF(b *testing.B) {
+	for _, n := range []int{1, 10, 100, 1000, 10000} {
+		entries := make([]string, n)
+		for i := range entries {
+			entries[i] = "1.2.3.4"
+		}
+		headers := []string{strings.Join(entries, ", ")}
+
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				walkXFF(headers, func(entry string) bool {
+					return false // walk to the leftmost entry
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkWalkXFF_RightmostStop measures the common case for both
+// ClientIPFromXFF (no trusted prefixes => stop at the first / rightmost
+// entry) and ClientIPFromXFFTrustedProxies(1). Should be near-constant
+// regardless of n, since the walker stops after the first visit.
+func BenchmarkWalkXFF_RightmostStop(b *testing.B) {
+	for _, n := range []int{1, 10, 100, 1000, 10000} {
+		entries := make([]string, n)
+		for i := range entries {
+			entries[i] = "1.2.3.4"
+		}
+		headers := []string{strings.Join(entries, ", ")}
+
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				walkXFF(headers, func(entry string) bool {
+					return true // stop at the rightmost entry
+				})
+			}
+		})
+	}
+}

--- a/middleware/client_ip_example_test.go
+++ b/middleware/client_ip_example_test.go
@@ -29,10 +29,7 @@ import (
 //
 // Read the resulting IP with [middleware.GetClientIP] (string) or
 // [middleware.GetClientIPAddr] ([net/netip.Addr]). These middlewares never
-// mutate [net/http.Request.RemoteAddr]. If a middleware earlier in the chain
-// already set a client IP, later ClientIPFrom* middlewares are no-ops; this
-// lets you chain a primary with a fallback, e.g. ClientIPFromXFF("10.0.0.0/8")
-// followed by ClientIPFromRemoteAddr.
+// mutate [net/http.Request.RemoteAddr].
 //
 // The legacy [middleware.RealIP] middleware is deprecated; it is vulnerable
 // to IP spoofing (GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf).

--- a/middleware/client_ip_example_test.go
+++ b/middleware/client_ip_example_test.go
@@ -1,0 +1,82 @@
+package middleware_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// Example_clientIP shows how to choose a ClientIPFrom* middleware. There is
+// no safe default — pick exactly ONE based on your network setup:
+//
+//   - [middleware.ClientIPFromRemoteAddr] — this server is directly on the
+//     public internet, with no reverse proxy in front.
+//
+//   - [middleware.ClientIPFromHeader] — your reverse proxy sets a dedicated
+//     single-IP header (X-Real-IP, CF-Connecting-IP, X-Client-IP) and
+//     overwrites any client-supplied value for every request.
+//
+//   - [middleware.ClientIPFromXFF] — you sit behind one or more reverse
+//     proxies whose IP ranges you can enumerate (your VPC CIDR, Cloudflare's
+//     published IP list, etc.).
+//
+//   - [middleware.ClientIPFromXFFTrustedProxies] — you sit behind a known,
+//     fixed number of reverse proxies whose IPs are dynamic (autoscaling
+//     pools, ephemeral containers).
+//
+// Read the resulting IP with [middleware.GetClientIP] (string) or
+// [middleware.GetClientIPAddr] ([net/netip.Addr]). These middlewares never
+// mutate [net/http.Request.RemoteAddr]. If a middleware earlier in the chain
+// already set a client IP, later ClientIPFrom* middlewares are no-ops; this
+// lets you chain a primary with a fallback, e.g. ClientIPFromXFF("10.0.0.0/8")
+// followed by ClientIPFromRemoteAddr.
+//
+// The legacy [middleware.RealIP] middleware is deprecated; it is vulnerable
+// to IP spoofing (GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf).
+//
+// Background:
+// https://github.com/go-chi/chi/pull/967
+// https://adam-p.ca/blog/2022/03/x-forwarded-for/
+func Example_clientIP() {
+	r := chi.NewRouter()
+
+	// Pick ONE; the others are shown commented for reference.
+
+	// (1) Behind a reverse proxy that sets a single-IP header for every
+	// request and overwrites any client-supplied value (Cloudflare, Nginx
+	// with ngx_http_realip_module, Apache with mod_remoteip, ...).
+	r.Use(middleware.ClientIPFromHeader("CF-Connecting-IP"))
+
+	// (2) Behind reverse proxies whose IP ranges you can enumerate as CIDRs.
+	// The middleware walks X-Forwarded-For right-to-left, skipping trusted
+	// entries.
+	//
+	// r.Use(middleware.ClientIPFromXFF(
+	//     "13.32.0.0/15",   // CloudFront IPv4.
+	//     "2600:9000::/28", // CloudFront IPv6.
+	// ))
+
+	// (3) Behind a known number of trusted reverse proxies whose IPs are
+	// dynamic.
+	//
+	// r.Use(middleware.ClientIPFromXFFTrustedProxies(2))
+
+	// (4) Directly on the public internet, no reverse proxy in front.
+	//
+	// r.Use(middleware.ClientIPFromRemoteAddr)
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, middleware.GetClientIP(r.Context()))
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("CF-Connecting-IP", "198.51.100.42")
+	req.Header.Set("X-Forwarded-For", "1.2.3.4") // attacker-supplied; ignored.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	fmt.Print(w.Body.String())
+	// Output: 198.51.100.42
+}

--- a/middleware/client_ip_example_test.go
+++ b/middleware/client_ip_example_test.go
@@ -49,7 +49,7 @@ func Example_clientIP() {
 
 	// (2) Behind reverse proxies whose IP ranges you can enumerate as CIDRs.
 	// The middleware walks X-Forwarded-For right-to-left, skipping trusted
-	// entries.
+	// entries; fail-closed on garbage.
 	//
 	// r.Use(middleware.ClientIPFromXFF(
 	//     "13.32.0.0/15",   // CloudFront IPv4.

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -1,0 +1,141 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestClientIPFromHeader(t *testing.T) {
+	tt := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		// Empty header.
+		{name: "empty", in: "", out: ""},
+
+		// Valid X-Real-IP header values.
+		{name: "valid_ipv4", in: "100.100.100.100", out: "100.100.100.100"},
+		{name: "valid_ipv4", in: "178.25.203.2", out: "178.25.203.2"},
+		{name: "valid_ipv6_lower", in: "2345:0425:2ca1:0000:0000:0567:5673:23b5", out: "2345:425:2ca1::567:5673:23b5"},
+		{name: "valid_ipv6_upper", in: "2345:0425:2CA1:0000:0000:0567:5673:23B5", out: "2345:425:2ca1::567:5673:23b5"},
+		{name: "valid_ipv6_lower_short", in: "2345:425:2ca1::567:5673:23b5", out: "2345:425:2ca1::567:5673:23b5"},
+		{name: "valid_ipv6_upper_short", in: "2345:425:2CA1::567:5673:23B5", out: "2345:425:2ca1::567:5673:23b5"},
+
+		// Invalid X-Real-IP header values.
+		{name: "invalid_ip", in: "invalid", out: ""},
+		{name: "invalid_ip_with_port", in: "100.100.100.100:80", out: ""},
+		{name: "invalid_multiple_ips", in: "100.100.100.100;100.100.100.101;100.100.100.102", out: ""},
+		{name: "invalid_loopback", in: "127.0.0.1", out: ""},
+		{name: "invalid_zeroes", in: "0.0.0.0", out: ""},
+		{name: "invalid_loopback", in: "127.0.0.1", out: ""},
+		{name: "invalid_private_ipv4_1", in: "192.168.0.1", out: ""},
+		{name: "invalid_private_ipv4_2", in: "192.168.10.12", out: ""},
+		{name: "invalid_private_ipv4_3", in: "172.16.0.0", out: ""},
+		{name: "invalid_private_ipv4_4", in: "172.25.203.2", out: ""},
+		{name: "invalid_private_ipv4_5", in: "10.0.0.0", out: ""},
+		{name: "invalid_private_ipv4_6", in: "10.0.1.10", out: ""},
+		{name: "invalid_private_ipv6_1", in: "fc00::1", out: ""},
+		{name: "invalid_private_ipv6_2", in: "fc00:0425:2ca1:0000:0000:0567:5673:23b5", out: ""},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			req.Header.Add("X-Real-IP", tc.in)
+			w := httptest.NewRecorder()
+
+			r := chi.NewRouter()
+			r.Use(ClientIPFromHeader("X-Real-IP"))
+
+			var clientIP string
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				clientIP = GetClientIP(r.Context())
+				w.Write([]byte("Hello World"))
+			})
+			r.ServeHTTP(w, req)
+
+			if w.Code != 200 {
+				t.Errorf("Response Code should be 200")
+			}
+
+			if clientIP != tc.out {
+				t.Errorf("expected %v, got %v", tc.out, clientIP)
+			}
+		})
+	}
+}
+
+func TestClientIPFromXFFHeader(t *testing.T) {
+	tt := []struct {
+		name string
+		xff  []string
+		out  string
+	}{
+		{name: "empty", xff: []string{""}, out: ""},
+
+		{name: "", xff: []string{"100.100.100.100"}, out: "100.100.100.100"},
+		{name: "", xff: []string{"100.100.100.100, 200.200.200.200"}, out: "200.200.200.200"},
+		{name: "", xff: []string{"100.100.100.100,200.200.200.200"}, out: "200.200.200.200"},
+		{name: "", xff: []string{"100.100.100.100", "200.200.200.200"}, out: "200.200.200.200"},
+		{name: "", xff: []string{"2001:db8:85a3:8d3:1319:8a2e:370:7348"}, out: "2001:db8:85a3:8d3:1319:8a2e:370:7348"},
+		{name: "", xff: []string{"203.0.113.195, 2001:db8:85a3:8d3:1319:8a2e:370:7348"}, out: "2001:db8:85a3:8d3:1319:8a2e:370:7348"},
+		{name: "", xff: []string{"5.5.5.5, 203.0.113.195, 2001:db8:85a3:8d3:1319:8a2e:370:7348", "7.7.7.7, 4.4.4.4"}, out: "4.4.4.4"},
+	}
+
+	r := chi.NewRouter()
+	r.Use(ClientIPFromXFFHeader())
+
+	for _, tc := range tt {
+		req, _ := http.NewRequest("GET", "/", nil)
+		for _, v := range tc.xff {
+			req.Header.Add("X-Forwarded-For", v)
+		}
+
+		w := httptest.NewRecorder()
+
+		clientIP := ""
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			clientIP = GetClientIP(r.Context())
+			w.Write([]byte("Hello World"))
+		})
+		r.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Errorf("Response Code should be 200")
+		}
+
+		if clientIP != tc.out {
+			t.Errorf("expected %v, got %v", tc.out, clientIP)
+		}
+	}
+}
+
+func TestClientIPFromRemoteAddr(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.0.2.1:1234" // Simulate the remote address set by http.Server.
+
+	w := httptest.NewRecorder()
+
+	r := chi.NewRouter()
+	r.Use(ClientIPFromRemoteAddr)
+
+	var clientIP string
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		clientIP = GetClientIP(r.Context())
+		w.Write([]byte("Hello World"))
+	})
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("Response Code should be 200")
+	}
+
+	expected := "192.0.2.1"
+	if clientIP != expected {
+		t.Errorf("expected %v, got %v", expected, clientIP)
+	}
+}

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -487,6 +487,64 @@ func TestXFF_MultipleHeadersMerged(t *testing.T) {
 	}
 }
 
+// TestClientIPFromHeader_MultiValueLastWins demonstrates a defense-in-depth
+// gap in ClientIPFromHeader: it reads the trusted single-IP header with
+// r.Header.Get(), which returns only the FIRST header value Go saw on the
+// wire. If a misconfigured proxy appends to the trusted header (or sits
+// downstream of another proxy that already set it), Go's net/http preserves
+// both as separate values in r.Header[CanonicalKey]. Today we surface
+// values[0] — and an attacker who sent the trusted header themselves can
+// place themselves in that slot.
+//
+// The trusted hop is the one CLOSEST to us, which means the LAST value
+// added (rightmost). Same rightmost-untrusted spirit as ClientIPFromXFF:
+// values from hops further from us are more spoofable, so the right hop
+// to trust is the one nearest to us in the chain.
+//
+// Pinned post-fix behavior: ClientIPFromHeader reads r.Header.Values()
+// and uses the last entry. Multi-value headers fail-close on garbage at
+// the last position (we do NOT fall back to earlier values — those could
+// be attacker-supplied).
+func TestClientIPFromHeader_MultiValueLastWins(t *testing.T) {
+	tt := []struct {
+		name   string
+		values []string // appended in order via Header.Add
+		out    string
+	}{
+		// Baseline: single value (the well-configured case) still works.
+		{"single_value_unchanged", []string{"100.1.1.1"}, "100.1.1.1"},
+
+		// Attack: attacker sets X-Real-IP, then proxy appends (instead of
+		// overwriting) its own value. Last value (the proxy's) must win.
+		{"attacker_then_proxy", []string{"6.6.6.6", "100.2.2.2"}, "100.2.2.2"},
+
+		// Three hops; only the last is trusted.
+		{"three_values_last_wins", []string{"6.6.6.6", "5.5.5.5", "100.3.3.3"}, "100.3.3.3"},
+
+		// Fail-closed: last value is garbage. We do NOT fall back to the
+		// previous value — that value was set by someone further from us in
+		// the chain and is by definition less trustworthy than what our
+		// nearest hop produced (even if what they produced is garbage).
+		{"last_unparseable_no_fallback", []string{"100.4.4.4", "garbage"}, ""},
+
+		// Fail-closed: last value is empty. Same rationale.
+		{"last_empty_no_fallback", []string{"100.5.5.5", ""}, ""},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, ClientIPFromHeader("X-Real-IP"), func(r *http.Request) {
+				for _, v := range tc.values {
+					r.Header.Add("X-Real-IP", v)
+				}
+			})
+			if got != tc.out {
+				t.Errorf("VULNERABLE or wrong: want %q, got %q", tc.out, got)
+			}
+		})
+	}
+}
+
 // TestXFF_V4MappedIPv6BypassesTrustedV4Prefix demonstrates a gap in the
 // rightmost-untrusted walker: netip.Prefix.Contains returns false when an
 // IPv4-mapped IPv6 address (::ffff:a.b.c.d) is checked against a plain v4

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -247,16 +247,18 @@ func TestClientIPFromRemoteAddr(t *testing.T) {
 	}
 }
 
-// Chaining: each ClientIPFrom* middleware always runs and overwrites if it
-// finds a value; the last one with a value wins. To get primary+fallback
-// behavior, order is "fallback first, preferred last".
-func TestClientIPChaining(t *testing.T) {
-	// Preferred middleware runs LAST and overrides the fallback.
-	t.Run("header_overrides_xff_when_set", func(t *testing.T) {
+// TestClientIPLastWriteWins locks down the implementation property that each
+// ClientIPFrom* middleware unconditionally overwrites the context value when
+// it finds a valid IP, while leaving any previously stored value alone when
+// it doesn't. Application code should pick exactly one ClientIPFrom*
+// middleware; this test only guards against an accidental return to
+// first-write-wins semantics.
+func TestClientIPLastWriteWins(t *testing.T) {
+	t.Run("later_overrides_earlier", func(t *testing.T) {
 		got := runChain(t,
 			[]func(http.Handler) http.Handler{
-				ClientIPFromXFF(),                      // fallback.
-				ClientIPFromHeader("CF-Connecting-IP"), // preferred.
+				ClientIPFromXFF(),
+				ClientIPFromHeader("CF-Connecting-IP"),
 			},
 			func(r *http.Request) {
 				r.Header.Set("CF-Connecting-IP", "1.1.1.1")
@@ -267,8 +269,7 @@ func TestClientIPChaining(t *testing.T) {
 		}
 	})
 
-	// Preferred middleware finds nothing, so the fallback's value persists.
-	t.Run("xff_persists_when_header_missing", func(t *testing.T) {
+	t.Run("earlier_persists_when_later_finds_nothing", func(t *testing.T) {
 		got := runChain(t,
 			[]func(http.Handler) http.Handler{
 				ClientIPFromXFF(),
@@ -282,9 +283,7 @@ func TestClientIPChaining(t *testing.T) {
 		}
 	})
 
-	// RemoteAddr as last-resort baseline; XFF would override but finds only
-	// trusted IPs, so the baseline persists.
-	t.Run("remoteaddr_fills_in_when_xff_finds_nothing", func(t *testing.T) {
+	t.Run("earlier_persists_when_later_xff_all_trusted", func(t *testing.T) {
 		got := runChain(t,
 			[]func(http.Handler) http.Handler{
 				ClientIPFromRemoteAddr,

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -487,24 +487,19 @@ func TestXFF_MultipleHeadersMerged(t *testing.T) {
 	}
 }
 
-// TestClientIPFromHeader_MultiValueLastWins demonstrates a defense-in-depth
-// gap in ClientIPFromHeader: it reads the trusted single-IP header with
-// r.Header.Get(), which returns only the FIRST header value Go saw on the
-// wire. If a misconfigured proxy appends to the trusted header (or sits
-// downstream of another proxy that already set it), Go's net/http preserves
-// both as separate values in r.Header[CanonicalKey]. Today we surface
-// values[0] — and an attacker who sent the trusted header themselves can
-// place themselves in that slot.
+// TestClientIPFromHeader_MultiValueLastWins is a regression pin for the
+// defense-in-depth gap fixed in a8e3dbf. The pre-fix implementation read
+// the trusted single-IP header with r.Header.Get(), which returns only
+// the first header value Go saw on the wire — so a misconfigured proxy
+// that appended (instead of overwriting) the trusted header, or any
+// chain where another proxy already set it, could surface an attacker-
+// controlled values[0].
 //
-// The trusted hop is the one CLOSEST to us, which means the LAST value
-// added (rightmost). Same rightmost-untrusted spirit as ClientIPFromXFF:
-// values from hops further from us are more spoofable, so the right hop
-// to trust is the one nearest to us in the chain.
-//
-// Pinned post-fix behavior: ClientIPFromHeader reads r.Header.Values()
-// and uses the last entry. Multi-value headers fail-close on garbage at
-// the last position (we do NOT fall back to earlier values — those could
-// be attacker-supplied).
+// Pinned post-fix contract: ClientIPFromHeader reads r.Header.Values()
+// and uses the LAST entry (closest hop = most trusted, same
+// rightmost-untrusted spirit as ClientIPFromXFF). Fail-closed on garbage
+// at the last position; we do NOT fall back to earlier values — those
+// came from hops further from us and are less trustworthy by definition.
 func TestClientIPFromHeader_MultiValueLastWins(t *testing.T) {
 	tt := []struct {
 		name   string

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -67,15 +67,16 @@ func TestClientIPFromXFF_NoTrustedPrefixes(t *testing.T) {
 		{"multi_header_with_commas", []string{"5.5.5.5, 6.6.6.6", "7.7.7.7, 4.4.4.4"}, "4.4.4.4"},
 		{"ipv6", []string{"2001:db8::1"}, "2001:db8::1"},
 		{"mixed_v4_v6_rightmost_wins", []string{"203.0.113.1, 2001:db8::1"}, "2001:db8::1"},
-		{"unparseable_rightmost_skipped", []string{"1.1.1.1, garbage"}, "1.1.1.1"},
 
 		// Normalization at the entry point: v4-mapped IPv6 folds to v4, zone stripped.
 		{"v4_mapped_rightmost_folded", []string{"::ffff:1.2.3.4"}, "1.2.3.4"},
 		{"zone_stripped_rightmost", []string{"2001:db8::1%eth0"}, "2001:db8::1"},
 
 		// A header like "oh, hi,,127.0.0.1,,,," can be injected by the client.
+		// The walker reaches 127.0.0.1 from the right before encountering the
+		// unparseable tokens, so fail-closed never trips here.
 		// See https://adam-p.ca/blog/2022/03/x-forwarded-for/ for more details.
-		{"weird_with_empties_and_garbage", []string{"oh, hi,,127.0.0.1,,,,"}, "127.0.0.1"},
+		{"weird_with_empties_then_valid_rightmost", []string{"oh, hi,,127.0.0.1,,,,"}, "127.0.0.1"},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -578,6 +579,75 @@ func TestClientIPFromRemoteAddr_V4MappedIsUnmapped(t *testing.T) {
 			})
 			if got != tc.out {
 				t.Errorf("want %q (unmapped v4 form), got %q", tc.out, got)
+			}
+		})
+	}
+}
+
+// TestXFF_FailClosedOnUnparseable pins the fail-closed contract for the
+// rightmost-untrusted XFF walk (PR #967 review issue #6, adam-p): if the
+// walker encounters an entry that does not parse as an IP, it MUST abandon
+// the walk and leave no client IP set. Rightmost-untrusted relies on being
+// able to read every hop to the right of the client; an unparseable hop is
+// indistinguishable from a hostile or missing one, so we cannot safely keep
+// walking past it.
+//
+// Empty / whitespace-only entries are NOT parse failures — they are dropped
+// by trim before parsing, and do not trip fail-closed.
+//
+// These tests are EXPECTED TO FAIL until the fail-closed change lands in
+// rightmostUntrustedXFF.
+func TestXFF_FailClosedOnUnparseable(t *testing.T) {
+	tt := []struct {
+		name     string
+		prefixes []string
+		xff      []string
+		out      string
+	}{
+		// Rightmost entry is garbage — walker fails closed before reaching the
+		// otherwise-valid 1.1.1.1 to the left. Without fail-closed, garbage
+		// to the right of a real client could be silently elided.
+		{
+			name: "garbage_rightmost_no_prefixes",
+			xff:  []string{"1.1.1.1, garbage"},
+			out:  "",
+		},
+		// Garbage between the client and a trusted proxy hop. Without fail-
+		// closed, the walker would skip the trusted hop, silently skip the
+		// garbage, and return 203.0.113.7 — a spoofable result.
+		{
+			name:     "garbage_between_client_and_trusted_proxy",
+			prefixes: []string{"10.0.0.0/8"},
+			xff:      []string{"203.0.113.7, garbage, 10.0.0.1"},
+			out:      "",
+		},
+		// Garbage past a multi-hop trusted chain. Same shape with more
+		// trusted hops in front; behaviour must be identical.
+		{
+			name:     "garbage_past_trusted_chain",
+			prefixes: []string{"10.0.0.0/8"},
+			xff:      []string{"203.0.113.7, garbage, 10.0.0.1, 10.0.0.2"},
+			out:      "",
+		},
+		// Negative case: garbage sits in a left-hand header that the walker
+		// never reaches because it returns at a valid untrusted entry first.
+		// Fail-closed must NOT over-trigger here.
+		{
+			name:     "garbage_in_unreachable_left_header",
+			prefixes: []string{"10.0.0.0/8"},
+			xff:      []string{"garbage", "203.0.113.7, 10.0.0.1"},
+			out:      "203.0.113.7",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, ClientIPFromXFF(tc.prefixes...), func(r *http.Request) {
+				for _, v := range tc.xff {
+					r.Header.Add("X-Forwarded-For", v)
+				}
+			})
+			if got != tc.out {
+				t.Errorf("want %q, got %q", tc.out, got)
 			}
 		})
 	}

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -467,6 +467,103 @@ func TestXFF_MultipleHeadersMerged(t *testing.T) {
 	}
 }
 
+// TestXFF_V4MappedIPv6BypassesTrustedV4Prefix demonstrates a gap in
+// rightmostUntrustedXFF: netip.Prefix.Contains returns false when an
+// IPv4-mapped IPv6 address (::ffff:a.b.c.d) is checked against a plain v4
+// prefix. So an attacker who can inject the v4-mapped form of an internal
+// address into XFF — and whose own connecting IP happens to be in the
+// trusted range (e.g. a compromised host inside an internal VPC) — gets a
+// trusted-looking value returned as "the client IP". Any downstream code
+// that treats internal IPs as privileged (rate-limit exemptions, internal
+// admin allowlists, audit pipelines) then mis-classifies the request.
+//
+// The expected post-fix behavior is to Unmap() before the prefix check, so
+// ::ffff:10.0.0.5 is recognized as 10.0.0.5 and skipped along with the rest
+// of the trusted chain — leaving no untrusted IP and an empty GetClientIP.
+//
+// This test is EXPECTED TO FAIL until the Unmap fix lands.
+func TestXFF_V4MappedIPv6BypassesTrustedV4Prefix(t *testing.T) {
+	tt := []struct {
+		name     string
+		prefixes []string
+		xff      string
+		out      string
+	}{
+		{
+			name:     "internal_address_via_v4_mapped",
+			prefixes: []string{"10.0.0.0/8"},
+			xff:      "::ffff:10.0.0.5, 10.0.0.1",
+			out:      "",
+		},
+		{
+			name:     "loopback_via_v4_mapped",
+			prefixes: []string{"127.0.0.0/8", "10.0.0.0/8"},
+			xff:      "::ffff:127.0.0.1, 10.0.0.1",
+			out:      "",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, ClientIPFromXFF(tc.prefixes...), func(r *http.Request) {
+				r.Header.Set("X-Forwarded-For", tc.xff)
+			})
+			if got != tc.out {
+				t.Errorf("VULNERABLE: v4-mapped IPv6 escaped v4 trusted prefix — want %q, got %q", tc.out, got)
+			}
+		})
+	}
+}
+
+// TestXFF_IPv6ZoneIDBypassesTrustedV6Prefix demonstrates the same shape of
+// gap for IPv6 trust prefixes: netip.Prefix.Contains returns false for any
+// zoned IPv6 address, so an attacker-injected zone suffix escapes the trust
+// check and the value is returned as "the client IP". Zone IDs are
+// link-local concepts; they have no meaning on the wire and should never
+// appear in a real XFF chain.
+//
+// The expected post-fix behavior is to strip the zone before the prefix
+// check (or reject zoned addresses as parse failures), so 2606:4700::1%foo
+// is recognized as in 2606:4700::/32 and skipped.
+//
+// This test is EXPECTED TO FAIL until the zone-strip fix lands.
+func TestXFF_IPv6ZoneIDBypassesTrustedV6Prefix(t *testing.T) {
+	got := run(t, ClientIPFromXFF("2606:4700::/32"), func(r *http.Request) {
+		r.Header.Set("X-Forwarded-For", "2606:4700::1%attacker, 2606:4700::5")
+	})
+	if got != "" {
+		t.Errorf("VULNERABLE: zoned IPv6 escaped v6 trusted prefix — want %q, got %q", "", got)
+	}
+}
+
+// TestClientIPFromRemoteAddr_V4MappedIsUnmapped pins the desired
+// normalization for v4 connections accepted on a dual-stack listener:
+// Go's net/http surfaces those as ::ffff:a.b.c.d in r.RemoteAddr, and
+// returning them in that v6 form splits one logical client across two
+// rate-limit buckets, log keys, and prefix-check buckets depending on
+// listener configuration. The fix is to Unmap() before storing.
+//
+// This test is EXPECTED TO FAIL until the Unmap fix lands.
+func TestClientIPFromRemoteAddr_V4MappedIsUnmapped(t *testing.T) {
+	tt := []struct {
+		name       string
+		remoteAddr string
+		out        string
+	}{
+		{"v4_mapped_with_port", "[::ffff:1.2.3.4]:1234", "1.2.3.4"},
+		{"v4_mapped_bare", "::ffff:1.2.3.4", "1.2.3.4"},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, ClientIPFromRemoteAddr, func(r *http.Request) {
+				r.RemoteAddr = tc.remoteAddr
+			})
+			if got != tc.out {
+				t.Errorf("want %q (unmapped v4 form), got %q", tc.out, got)
+			}
+		})
+	}
+}
+
 // run invokes mw with the request constructed by buildReq and returns the
 // client IP captured inside the handler (or "" if none was set).
 func run(t *testing.T, mw func(http.Handler) http.Handler, buildReq func(*http.Request)) string {

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -200,25 +200,25 @@ func TestClientIPFromXFFTrustedProxies(t *testing.T) {
 		{"shorter_than_n", 3, []string{"1.1.1.1, 2.2.2.2"}, ""},
 		{"missing_header", 1, nil, ""},
 
-		// Spoofing: prepended attacker values are to the LEFT of the chosen slot,
-		// so they're ignored.
+		// Spoofing: prepended attacker values are to the LEFT of the chosen
+		// position, so they're ignored.
 		{"spoof_prepend_ignored", 2, []string{"6.6.6.6, 1.1.1.1, 2.2.2.2, 3.3.3.3"}, "2.2.2.2"},
 
-		// Bad parse at the target slot: no IP set (don't accept garbage as client IP).
-		{"bad_parse_at_slot", 2, []string{"garbage, 2.2.2.2"}, ""},
+		// Bad parse at the target position: no IP set (don't accept garbage as client IP).
+		{"bad_parse_at_position", 2, []string{"garbage, 2.2.2.2"}, ""},
 
 		// Merging across multiple header instances.
 		{"multi_header", 2, []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}, "2.2.2.2"},
 
-		// Empty entries dropped by mergeXFF must not shift the slot index. The
-		// slot is computed from the right, where trusted proxies append, so an
-		// attacker prepending commas can't slide their chosen value into the
-		// trusted slot.
-		{"empties_dont_shift_slot", 2, []string{",,, 3.3.3.3, 1.1.1.1, 2.2.2.2"}, "1.1.1.1"},
+		// Empty entries dropped by the walker must not shift the chosen
+		// position. The position is computed from the right, where trusted
+		// proxies append, so an attacker prepending commas can't slide their
+		// chosen value into the trusted position.
+		{"empties_dont_shift_position", 2, []string{",,, 3.3.3.3, 1.1.1.1, 2.2.2.2"}, "1.1.1.1"},
 
-		// Normalization at the chosen slot: v4-mapped IPv6 folds to v4, zone stripped.
-		{"v4_mapped_at_slot_folded", 1, []string{"::ffff:1.2.3.4"}, "1.2.3.4"},
-		{"zone_stripped_at_slot", 1, []string{"2001:db8::1%eth0"}, "2001:db8::1"},
+		// Normalization at the chosen position: v4-mapped IPv6 folds to v4, zone stripped.
+		{"v4_mapped_at_position_folded", 1, []string{"::ffff:1.2.3.4"}, "1.2.3.4"},
+		{"zone_stripped_at_position", 1, []string{"2001:db8::1%eth0"}, "2001:db8::1"},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -487,8 +487,8 @@ func TestXFF_MultipleHeadersMerged(t *testing.T) {
 	}
 }
 
-// TestXFF_V4MappedIPv6BypassesTrustedV4Prefix demonstrates a gap in
-// rightmostUntrustedXFF: netip.Prefix.Contains returns false when an
+// TestXFF_V4MappedIPv6BypassesTrustedV4Prefix demonstrates a gap in the
+// rightmost-untrusted walker: netip.Prefix.Contains returns false when an
 // IPv4-mapped IPv6 address (::ffff:a.b.c.d) is checked against a plain v4
 // prefix. So an attacker who can inject the v4-mapped form of an internal
 // address into XFF — and whose own connecting IP happens to be in the
@@ -596,7 +596,7 @@ func TestClientIPFromRemoteAddr_V4MappedIsUnmapped(t *testing.T) {
 // by trim before parsing, and do not trip fail-closed.
 //
 // These tests are EXPECTED TO FAIL until the fail-closed change lands in
-// rightmostUntrustedXFF.
+// the ClientIPFromXFF walker.
 func TestXFF_FailClosedOnUnparseable(t *testing.T) {
 	tt := []struct {
 		name     string

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -14,128 +15,485 @@ func TestClientIPFromHeader(t *testing.T) {
 		in   string
 		out  string
 	}{
-		// Empty header.
-		{name: "empty", in: "", out: ""},
+		{"empty", "", ""},
+		{"ipv4", "100.100.100.100", "100.100.100.100"},
+		{"ipv6_canonical", "2345:425:2ca1::567:5673:23b5", "2345:425:2ca1::567:5673:23b5"},
+		{"ipv6_uncompressed_normalized", "2345:0425:2CA1:0000:0000:0567:5673:23B5", "2345:425:2ca1::567:5673:23b5"},
 
-		// Valid X-Real-IP header values.
-		{name: "valid_ipv4", in: "100.100.100.100", out: "100.100.100.100"},
-		{name: "valid_ipv4", in: "178.25.203.2", out: "178.25.203.2"},
-		{name: "valid_ipv6_lower", in: "2345:0425:2ca1:0000:0000:0567:5673:23b5", out: "2345:425:2ca1::567:5673:23b5"},
-		{name: "valid_ipv6_upper", in: "2345:0425:2CA1:0000:0000:0567:5673:23B5", out: "2345:425:2ca1::567:5673:23b5"},
-		{name: "valid_ipv6_lower_short", in: "2345:425:2ca1::567:5673:23b5", out: "2345:425:2ca1::567:5673:23b5"},
-		{name: "valid_ipv6_upper_short", in: "2345:425:2CA1::567:5673:23B5", out: "2345:425:2ca1::567:5673:23b5"},
+		// netip.ParseAddr rejects non-IPs and embedded ports.
+		{"invalid", "invalid", ""},
+		{"ipv4_with_port", "100.100.100.100:80", ""},
+		{"multiple_ips", "100.100.100.100,200.200.200.200", ""},
 
-		// Invalid X-Real-IP header values.
-		{name: "invalid_ip", in: "invalid", out: ""},
-		{name: "invalid_ip_with_port", in: "100.100.100.100:80", out: ""},
-		{name: "invalid_multiple_ips", in: "100.100.100.100;100.100.100.101;100.100.100.102", out: ""},
-		{name: "invalid_loopback", in: "127.0.0.1", out: ""},
-		{name: "invalid_zeroes", in: "0.0.0.0", out: ""},
-		{name: "invalid_loopback", in: "127.0.0.1", out: ""},
-		{name: "invalid_private_ipv4_1", in: "192.168.0.1", out: ""},
-		{name: "invalid_private_ipv4_2", in: "192.168.10.12", out: ""},
-		{name: "invalid_private_ipv4_3", in: "172.16.0.0", out: ""},
-		{name: "invalid_private_ipv4_4", in: "172.25.203.2", out: ""},
-		{name: "invalid_private_ipv4_5", in: "10.0.0.0", out: ""},
-		{name: "invalid_private_ipv4_6", in: "10.0.1.10", out: ""},
-		{name: "invalid_private_ipv6_1", in: "fc00::1", out: ""},
-		{name: "invalid_private_ipv6_2", in: "fc00:0425:2ca1:0000:0000:0567:5673:23b5", out: ""},
+		// Per the blog and the three GHSAs: we trust the user's choice of header.
+		// If their infra writes a private/loopback IP here, that IS the answer.
+		{"loopback_accepted", "127.0.0.1", "127.0.0.1"},
+		{"private_v4_accepted", "10.0.1.10", "10.0.1.10"},
+		{"private_v6_accepted", "fc00::1", "fc00::1"},
+		{"unspecified_accepted", "0.0.0.0", "0.0.0.0"},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/", nil)
-			req.Header.Add("X-Real-IP", tc.in)
-			w := httptest.NewRecorder()
-
-			r := chi.NewRouter()
-			r.Use(ClientIPFromHeader("X-Real-IP"))
-
-			var clientIP string
-			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-				clientIP = GetClientIP(r.Context())
-				w.Write([]byte("Hello World"))
+			got := run(t, ClientIPFromHeader("X-Real-IP"), func(r *http.Request) {
+				if tc.in != "" {
+					r.Header.Set("X-Real-IP", tc.in)
+				}
 			})
-			r.ServeHTTP(w, req)
-
-			if w.Code != 200 {
-				t.Errorf("Response Code should be 200")
-			}
-
-			if clientIP != tc.out {
-				t.Errorf("expected %v, got %v", tc.out, clientIP)
+			if got != tc.out {
+				t.Errorf("want %q, got %q", tc.out, got)
 			}
 		})
 	}
 }
 
-func TestClientIPFromXFFHeader(t *testing.T) {
+func TestClientIPFromXFF_NoTrustedPrefixes(t *testing.T) {
 	tt := []struct {
 		name string
 		xff  []string
 		out  string
 	}{
-		{name: "empty", xff: []string{""}, out: ""},
+		{"missing", nil, ""},
+		{"empty", []string{""}, ""},
+		{"single", []string{"100.100.100.100"}, "100.100.100.100"},
+		{"comma_space", []string{"1.1.1.1, 2.2.2.2"}, "2.2.2.2"},
+		{"comma_no_space", []string{"1.1.1.1,2.2.2.2"}, "2.2.2.2"},
+		{"multi_header_merged", []string{"1.1.1.1", "2.2.2.2"}, "2.2.2.2"},
+		{"multi_header_with_commas", []string{"5.5.5.5, 6.6.6.6", "7.7.7.7, 4.4.4.4"}, "4.4.4.4"},
+		{"ipv6", []string{"2001:db8::1"}, "2001:db8::1"},
+		{"mixed_v4_v6_rightmost_wins", []string{"203.0.113.1, 2001:db8::1"}, "2001:db8::1"},
+		{"unparseable_rightmost_skipped", []string{"1.1.1.1, garbage"}, "1.1.1.1"},
 
-		{name: "", xff: []string{"100.100.100.100"}, out: "100.100.100.100"},
-		{name: "", xff: []string{"100.100.100.100, 200.200.200.200"}, out: "200.200.200.200"},
-		{name: "", xff: []string{"100.100.100.100,200.200.200.200"}, out: "200.200.200.200"},
-		{name: "", xff: []string{"100.100.100.100", "200.200.200.200"}, out: "200.200.200.200"},
-		{name: "", xff: []string{"2001:db8:85a3:8d3:1319:8a2e:370:7348"}, out: "2001:db8:85a3:8d3:1319:8a2e:370:7348"},
-		{name: "", xff: []string{"203.0.113.195, 2001:db8:85a3:8d3:1319:8a2e:370:7348"}, out: "2001:db8:85a3:8d3:1319:8a2e:370:7348"},
-		{name: "", xff: []string{"5.5.5.5, 203.0.113.195, 2001:db8:85a3:8d3:1319:8a2e:370:7348", "7.7.7.7, 4.4.4.4"}, out: "4.4.4.4"},
+		// A header like "oh, hi,,127.0.0.1,,,," can be injected by the client.
+		// See https://adam-p.ca/blog/2022/03/x-forwarded-for/ for more details.
+		{"weird_with_empties_and_garbage", []string{"oh, hi,,127.0.0.1,,,,"}, "127.0.0.1"},
 	}
-
-	r := chi.NewRouter()
-	r.Use(ClientIPFromXFFHeader())
-
 	for _, tc := range tt {
-		req, _ := http.NewRequest("GET", "/", nil)
-		for _, v := range tc.xff {
-			req.Header.Add("X-Forwarded-For", v)
-		}
-
-		w := httptest.NewRecorder()
-
-		clientIP := ""
-		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-			clientIP = GetClientIP(r.Context())
-			w.Write([]byte("Hello World"))
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, ClientIPFromXFF(), func(r *http.Request) {
+				for _, v := range tc.xff {
+					r.Header.Add("X-Forwarded-For", v)
+				}
+			})
+			if got != tc.out {
+				t.Errorf("want %q, got %q", tc.out, got)
+			}
 		})
-		r.ServeHTTP(w, req)
-
-		if w.Code != 200 {
-			t.Errorf("Response Code should be 200")
-		}
-
-		if clientIP != tc.out {
-			t.Errorf("expected %v, got %v", tc.out, clientIP)
-		}
 	}
 }
 
+func TestClientIPFromXFF_TrustedPrefixes(t *testing.T) {
+	tt := []struct {
+		name     string
+		prefixes []string
+		xff      []string
+		out      string
+	}{
+		{
+			name:     "single_trusted_proxy_skipped",
+			prefixes: []string{"203.0.113.0/24"},
+			xff:      []string{"100.100.100.100, 203.0.113.50"},
+			out:      "100.100.100.100",
+		},
+		{
+			name:     "multiple_trusted_proxies_skipped",
+			prefixes: []string{"203.0.113.0/24", "198.51.100.0/24"},
+			xff:      []string{"1.1.1.1, 203.0.113.10, 198.51.100.5"},
+			out:      "1.1.1.1",
+		},
+		{
+			name:     "all_trusted_returns_empty",
+			prefixes: []string{"203.0.113.0/24"},
+			xff:      []string{"203.0.113.10, 203.0.113.20"},
+			out:      "",
+		},
+		{
+			name:     "ipv6_trusted_range",
+			prefixes: []string{"2606:4700::/32"},
+			xff:      []string{"2001:db8::1, 2606:4700::1"},
+			out:      "2001:db8::1",
+		},
+		{
+			name:     "mixed_v4_v6_trust_list",
+			prefixes: []string{"2606:4700::/32", "203.0.113.0/24"},
+			xff:      []string{"8.8.8.8, 2606:4700::1, 203.0.113.5"},
+			out:      "8.8.8.8",
+		},
+		// Adam-P's blog and rezmoss's advisory: we must NOT filter private/loopback
+		// values when they sit between trusted proxies. K8s nginx-ingress legitimately
+		// produces this shape.
+		{
+			name:     "private_between_trusted_is_client",
+			prefixes: []string{"10.244.0.0/24"},
+			xff:      []string{"10.244.1.50, 10.244.0.10"},
+			out:      "10.244.1.50",
+		},
+		// /24 boundary tests (Saku0512's PR #1087).
+		{
+			name:     "boundary_first_addr_in_prefix",
+			prefixes: []string{"203.0.113.0/24"},
+			xff:      []string{"100.100.100.100, 203.0.113.0"},
+			out:      "100.100.100.100",
+		},
+		{
+			name:     "boundary_last_addr_in_prefix",
+			prefixes: []string{"203.0.113.0/24"},
+			xff:      []string{"100.100.100.100, 203.0.113.255"},
+			out:      "100.100.100.100",
+		},
+		{
+			name:     "ip_just_outside_prefix_is_client",
+			prefixes: []string{"203.0.113.0/24"},
+			xff:      []string{"203.0.114.1, 203.0.113.1"},
+			out:      "203.0.114.1",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, ClientIPFromXFF(tc.prefixes...), func(r *http.Request) {
+				for _, v := range tc.xff {
+					r.Header.Add("X-Forwarded-For", v)
+				}
+			})
+			if got != tc.out {
+				t.Errorf("want %q, got %q", tc.out, got)
+			}
+		})
+	}
+}
+
+func TestClientIPFromXFF_PanicsOnBadPrefix(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on invalid CIDR")
+		}
+	}()
+	ClientIPFromXFF("not-a-cidr")
+}
+
+func TestClientIPFromXFFTrustedProxies(t *testing.T) {
+	tt := []struct {
+		name string
+		n    int
+		xff  []string
+		out  string
+	}{
+		// N=1 ⇒ rightmost (equivalent to ClientIPFromXFF() with no prefixes).
+		{"n1_rightmost", 1, []string{"1.1.1.1, 2.2.2.2"}, "2.2.2.2"},
+		{"n2_second_from_right", 2, []string{"1.1.1.1, 2.2.2.2, 3.3.3.3"}, "2.2.2.2"},
+		{"n3_third_from_right", 3, []string{"1.1.1.1, 2.2.2.2, 3.3.3.3, 4.4.4.4"}, "2.2.2.2"},
+		{"n2_exactly_matches_len", 2, []string{"1.1.1.1, 2.2.2.2"}, "1.1.1.1"},
+
+		// XFF shorter than N: no IP set. This is intentionally fail-closed so a
+		// proxy-count mismatch doesn't silently fall through to attacker-controlled
+		// values.
+		{"shorter_than_n", 3, []string{"1.1.1.1, 2.2.2.2"}, ""},
+		{"missing_header", 1, nil, ""},
+
+		// Spoofing: prepended attacker values are to the LEFT of the chosen slot,
+		// so they're ignored.
+		{"spoof_prepend_ignored", 2, []string{"6.6.6.6, 1.1.1.1, 2.2.2.2, 3.3.3.3"}, "2.2.2.2"},
+
+		// Bad parse at the target slot: no IP set (don't accept garbage as client IP).
+		{"bad_parse_at_slot", 2, []string{"garbage, 2.2.2.2"}, ""},
+
+		// Merging across multiple header instances.
+		{"multi_header", 2, []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}, "2.2.2.2"},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, ClientIPFromXFFTrustedProxies(tc.n), func(r *http.Request) {
+				for _, v := range tc.xff {
+					r.Header.Add("X-Forwarded-For", v)
+				}
+			})
+			if got != tc.out {
+				t.Errorf("want %q, got %q", tc.out, got)
+			}
+		})
+	}
+}
+
+func TestClientIPFromXFFTrustedProxies_PanicsOnZero(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic on numTrustedProxies < 1")
+		}
+	}()
+	ClientIPFromXFFTrustedProxies(0)
+}
+
 func TestClientIPFromRemoteAddr(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/", nil)
-	req.RemoteAddr = "192.0.2.1:1234" // Simulate the remote address set by http.Server.
+	tt := []struct {
+		name       string
+		remoteAddr string
+		out        string
+	}{
+		{"ipv4_with_port", "192.0.2.1:1234", "192.0.2.1"},
+		{"ipv6_with_port", "[2001:db8::1]:1234", "2001:db8::1"},
+		{"bare_ipv4", "192.0.2.1", "192.0.2.1"},
+		{"empty", "", ""},
+		{"garbage", "not-an-ip", ""},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := run(t, ClientIPFromRemoteAddr, func(r *http.Request) {
+				r.RemoteAddr = tc.remoteAddr
+			})
+			if got != tc.out {
+				t.Errorf("want %q, got %q", tc.out, got)
+			}
+		})
+	}
+}
 
-	w := httptest.NewRecorder()
-
-	r := chi.NewRouter()
-	r.Use(ClientIPFromRemoteAddr)
-
-	var clientIP string
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		clientIP = GetClientIP(r.Context())
-		w.Write([]byte("Hello World"))
+// Chaining (the first middleware to set wins; later ones are no-ops)
+func TestClientIPChaining(t *testing.T) {
+	t.Run("header_wins_over_xff", func(t *testing.T) {
+		got := runChain(t,
+			[]func(http.Handler) http.Handler{
+				ClientIPFromHeader("CF-Connecting-IP"),
+				ClientIPFromXFF(),
+			},
+			func(r *http.Request) {
+				r.Header.Set("CF-Connecting-IP", "1.1.1.1")
+				r.Header.Set("X-Forwarded-For", "2.2.2.2")
+			})
+		if got != "1.1.1.1" {
+			t.Errorf("want 1.1.1.1, got %q", got)
+		}
 	})
-	r.ServeHTTP(w, req)
 
-	if w.Code != 200 {
-		t.Errorf("Response Code should be 200")
-	}
+	t.Run("xff_falls_through_to_remoteaddr", func(t *testing.T) {
+		got := runChain(t,
+			[]func(http.Handler) http.Handler{
+				ClientIPFromXFF("10.0.0.0/8"),
+				ClientIPFromRemoteAddr,
+			},
+			func(r *http.Request) {
+				// XFF contains only trusted values → no IP set by ClientIPFromXFF.
+				r.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
+				r.RemoteAddr = "192.0.2.1:1234"
+			})
+		if got != "192.0.2.1" {
+			t.Errorf("want 192.0.2.1 (RemoteAddr fallback), got %q", got)
+		}
+	})
 
-	expected := "192.0.2.1"
-	if clientIP != expected {
-		t.Errorf("expected %v, got %v", expected, clientIP)
+	t.Run("missing_header_falls_through_to_xff", func(t *testing.T) {
+		got := runChain(t,
+			[]func(http.Handler) http.Handler{
+				ClientIPFromHeader("CF-Connecting-IP"),
+				ClientIPFromXFF(),
+			},
+			func(r *http.Request) {
+				r.Header.Set("X-Forwarded-For", "8.8.8.8")
+			})
+		if got != "8.8.8.8" {
+			t.Errorf("want 8.8.8.8 (XFF fallback), got %q", got)
+		}
+	})
+}
+
+func TestGetClientIPAddr_Unset(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	if got := GetClientIP(req.Context()); got != "" {
+		t.Errorf("GetClientIP on empty ctx: want %q, got %q", "", got)
 	}
+	if got := GetClientIPAddr(req.Context()); got.IsValid() {
+		t.Errorf("GetClientIPAddr on empty ctx: want zero, got %v", got)
+	}
+}
+
+func TestGetClientIPAddr_RoundTrip(t *testing.T) {
+	var gotStr string
+	var gotAddr netip.Addr
+	r := chi.NewRouter()
+	r.Use(ClientIPFromHeader("X-Real-IP"))
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		gotStr = GetClientIP(r.Context())
+		gotAddr = GetClientIPAddr(r.Context())
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Real-IP", "203.0.113.42")
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotStr != "203.0.113.42" {
+		t.Errorf("GetClientIP: want 203.0.113.42, got %q", gotStr)
+	}
+	if !gotAddr.IsValid() || gotAddr.String() != "203.0.113.42" {
+		t.Errorf("GetClientIPAddr: want 203.0.113.42, got %v", gotAddr)
+	}
+	if gotAddr.Is6() {
+		t.Errorf("GetClientIPAddr: want IPv4, got IPv6")
+	}
+}
+
+// GHSA-3fxj-6jh8-hvhx (Saku0512): an admin endpoint gates on the client IP,
+// and an attacker prepends a spoofed IP to X-Forwarded-For. middleware.RealIP
+// would set r.RemoteAddr from the leftmost XFF value, bypassing the gate.
+// The new ClientIPFrom* middlewares defeat this attack in both deployment
+// shapes the application might choose.
+func TestAdvisory_GHSA_3fxj_6jh8_hvhx(t *testing.T) {
+	// (a) Server directly on the internet: use ClientIPFromRemoteAddr.
+	// XFF is never consulted; the spoofed admin IP is ignored.
+	t.Run("direct_internet_uses_remoteaddr", func(t *testing.T) {
+		var clientIP string
+		r := chi.NewRouter()
+		r.Use(ClientIPFromRemoteAddr)
+		r.Get("/admin", func(w http.ResponseWriter, r *http.Request) {
+			clientIP = GetClientIP(r.Context())
+		})
+
+		req := httptest.NewRequest("GET", "/admin", nil)
+		req.RemoteAddr = "99.99.99.99:1234"
+		req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8") // attacker's spoof.
+		r.ServeHTTP(httptest.NewRecorder(), req)
+
+		if clientIP == "1.2.3.4" {
+			t.Fatal("VULNERABLE: returned attacker-supplied admin IP")
+		}
+		if clientIP != "99.99.99.99" {
+			t.Errorf("want 99.99.99.99 (real TCP peer), got %q", clientIP)
+		}
+	})
+
+	// (b) Server behind a trusted proxy: use ClientIPFromXFF with the proxy's
+	// CIDR. In a real deployment the trusted proxy APPENDS the attacker's
+	// real IP, so by the time the request reaches us the rightmost-untrusted
+	// entry is the genuine attacker IP, never the prepended spoof.
+	t.Run("behind_proxy_uses_xff", func(t *testing.T) {
+		got := run(t, ClientIPFromXFF("10.0.0.0/8"), func(r *http.Request) {
+			r.Header.Set("X-Forwarded-For", "1.2.3.4, 99.99.99.99")
+		})
+		if got == "1.2.3.4" {
+			t.Fatal("VULNERABLE: returned attacker-supplied admin IP")
+		}
+		if got != "99.99.99.99" {
+			t.Errorf("want 99.99.99.99 (rightmost-untrusted), got %q", got)
+		}
+	})
+}
+
+// GHSA-9g5q-2w5x-hmxf (convto): RealIP set r.RemoteAddr from the leftmost XFF
+// IP. With ClientIPFromXFF the rightmost-untrusted IP is selected, and we
+// never mutate r.RemoteAddr.
+func TestAdvisory_GHSA_9g5q_2w5x_hmxf(t *testing.T) {
+	originalRemoteAddr := "203.0.113.99:1234"
+
+	var capturedClientIP, capturedRemoteAddr string
+	r := chi.NewRouter()
+	r.Use(ClientIPFromXFF())
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		capturedClientIP = GetClientIP(r.Context())
+		capturedRemoteAddr = r.RemoteAddr
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "192.0.2.2, 192.0.2.1") // convto's PoC values.
+	req.RemoteAddr = originalRemoteAddr
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	// The rightmost value is the one added by our (single) trusted hop.
+	if capturedClientIP != "192.0.2.1" {
+		t.Errorf("client IP: want 192.0.2.1 (rightmost), got %q", capturedClientIP)
+	}
+	if capturedClientIP == "192.0.2.2" {
+		t.Errorf("VULNERABLE: returned attacker-supplied leftmost IP")
+	}
+	// Critical: r.RemoteAddr is never mutated, unlike middleware.RealIP.
+	if capturedRemoteAddr != originalRemoteAddr {
+		t.Errorf("r.RemoteAddr was mutated: want %q, got %q", originalRemoteAddr, capturedRemoteAddr)
+	}
+}
+
+// GHSA-rjr7-jggh-pgcp (rezmoss): RealIP trusted X-Real-IP / True-Client-IP /
+// X-Forwarded-For unconditionally and used the leftmost XFF value, allowing
+// "X-Forwarded-For: 127.0.0.1" to impersonate loopback. The new middleware
+// (a) requires the user to opt into a specific source and (b) uses
+// rightmost-untrusted for XFF.
+func TestAdvisory_GHSA_rjr7_jggh_pgcp(t *testing.T) {
+	// Attacker sends "X-Forwarded-For: 127.0.0.1" to spoof loopback. In a real
+	// deployment the trusted proxy appends the attacker's actual IP, so the
+	// rightmost-untrusted entry is never the loopback spoof.
+	t.Run("xff_loopback_spoof_rejected", func(t *testing.T) {
+		got := run(t, ClientIPFromXFF("10.0.0.0/8"), func(r *http.Request) {
+			r.Header.Set("X-Forwarded-For", "127.0.0.1, 99.99.99.99")
+		})
+		if got == "127.0.0.1" {
+			t.Fatal("VULNERABLE: returned attacker-supplied loopback")
+		}
+		if got != "99.99.99.99" {
+			t.Errorf("want 99.99.99.99 (rightmost-untrusted), got %q", got)
+		}
+	})
+
+	// Unlike RealIP, ClientIPFromHeader reads ONLY the header the user opted
+	// into. Attacker-supplied True-Client-IP / X-Forwarded-For are ignored.
+	t.Run("only_opted_in_header_is_read", func(t *testing.T) {
+		got := run(t, ClientIPFromHeader("X-Real-IP"), func(r *http.Request) {
+			r.Header.Set("True-Client-IP", "1.1.1.1")  // attacker-supplied; ignored.
+			r.Header.Set("X-Forwarded-For", "2.2.2.2") // attacker-supplied; ignored.
+			r.Header.Set("X-Real-IP", "203.0.113.7")   // set by the trusted proxy.
+		})
+		if got != "203.0.113.7" {
+			t.Errorf("want 203.0.113.7 (the only trusted header), got %q", got)
+		}
+	})
+}
+
+// "Multiple XFF headers" attack — Go's http.Header.Get returns only the first
+// value, but the security-relevant rightmost IP is in the LAST instance after
+// the proxy appends. We must merge all values; otherwise an attacker can pick
+// which header the server sees by sending a duplicate.
+//
+// See https://adam-p.ca/blog/2022/03/x-forwarded-for/ "Multiple headers".
+func TestXFF_MultipleHeadersMerged(t *testing.T) {
+	// Attacker sends two XFF headers; the trusted proxy appends to the second
+	// one (per RFC 2616). The genuine client is at the right of the merged
+	// chain. A naive http.Header.Get() implementation would only see the first
+	// header and return the attacker's prepended value.
+	got := run(t, ClientIPFromXFF("198.51.100.0/24"), func(r *http.Request) {
+		r.Header.Add("X-Forwarded-For", "127.0.0.1")             // attacker-injected.
+		r.Header.Add("X-Forwarded-For", "8.8.8.8, 198.51.100.1") // appended by trusted proxy.
+	})
+	if got != "8.8.8.8" {
+		t.Errorf("want 8.8.8.8, got %q", got)
+	}
+}
+
+// run invokes mw with the request constructed by buildReq and returns the
+// client IP captured inside the handler (or "" if none was set).
+func run(t *testing.T, mw func(http.Handler) http.Handler, buildReq func(*http.Request)) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/", nil)
+	buildReq(req)
+
+	var got string
+	r := chi.NewRouter()
+	r.Use(mw)
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		got = GetClientIP(r.Context())
+	})
+	r.ServeHTTP(httptest.NewRecorder(), req)
+	return got
+}
+
+// runChain is like run but applies multiple middlewares in order.
+func runChain(t *testing.T, mws []func(http.Handler) http.Handler, buildReq func(*http.Request)) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/", nil)
+	buildReq(req)
+
+	var got string
+	r := chi.NewRouter()
+	for _, mw := range mws {
+		r.Use(mw)
+	}
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		got = GetClientIP(r.Context())
+	})
+	r.ServeHTTP(httptest.NewRecorder(), req)
+	return got
 }

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -497,11 +497,10 @@ func TestXFF_MultipleHeadersMerged(t *testing.T) {
 // that treats internal IPs as privileged (rate-limit exemptions, internal
 // admin allowlists, audit pipelines) then mis-classifies the request.
 //
-// The expected post-fix behavior is to Unmap() before the prefix check, so
-// ::ffff:10.0.0.5 is recognized as 10.0.0.5 and skipped along with the rest
-// of the trusted chain — leaving no untrusted IP and an empty GetClientIP.
-//
-// This test is EXPECTED TO FAIL until the Unmap fix lands.
+// Pinned post-fix behavior: parseHeaderAddr calls Unmap() before the prefix
+// check, so ::ffff:10.0.0.5 is recognized as 10.0.0.5 and skipped along with
+// the rest of the trusted chain — leaving no untrusted IP and an empty
+// GetClientIP.
 func TestXFF_V4MappedIPv6BypassesTrustedV4Prefix(t *testing.T) {
 	tt := []struct {
 		name     string
@@ -541,11 +540,9 @@ func TestXFF_V4MappedIPv6BypassesTrustedV4Prefix(t *testing.T) {
 // link-local concepts; they have no meaning on the wire and should never
 // appear in a real XFF chain.
 //
-// The expected post-fix behavior is to strip the zone before the prefix
-// check (or reject zoned addresses as parse failures), so 2606:4700::1%foo
-// is recognized as in 2606:4700::/32 and skipped.
-//
-// This test is EXPECTED TO FAIL until the zone-strip fix lands.
+// Pinned post-fix behavior: parseHeaderAddr strips the zone before the
+// prefix check, so 2606:4700::1%attacker is recognized as in 2606:4700::/32
+// and skipped.
 func TestXFF_IPv6ZoneIDBypassesTrustedV6Prefix(t *testing.T) {
 	got := run(t, ClientIPFromXFF("2606:4700::/32"), func(r *http.Request) {
 		r.Header.Set("X-Forwarded-For", "2606:4700::1%attacker, 2606:4700::5")
@@ -560,9 +557,8 @@ func TestXFF_IPv6ZoneIDBypassesTrustedV6Prefix(t *testing.T) {
 // Go's net/http surfaces those as ::ffff:a.b.c.d in r.RemoteAddr, and
 // returning them in that v6 form splits one logical client across two
 // rate-limit buckets, log keys, and prefix-check buckets depending on
-// listener configuration. The fix is to Unmap() before storing.
-//
-// This test is EXPECTED TO FAIL until the Unmap fix lands.
+// listener configuration. Pinned post-fix behavior: ClientIPFromRemoteAddr
+// calls Unmap() before storing.
 func TestClientIPFromRemoteAddr_V4MappedIsUnmapped(t *testing.T) {
 	tt := []struct {
 		name       string
@@ -594,9 +590,6 @@ func TestClientIPFromRemoteAddr_V4MappedIsUnmapped(t *testing.T) {
 //
 // Empty / whitespace-only entries are NOT parse failures — they are dropped
 // by trim before parsing, and do not trip fail-closed.
-//
-// These tests are EXPECTED TO FAIL until the fail-closed change lands in
-// the ClientIPFromXFF walker.
 func TestXFF_FailClosedOnUnparseable(t *testing.T) {
 	tt := []struct {
 		name     string

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -247,13 +247,16 @@ func TestClientIPFromRemoteAddr(t *testing.T) {
 	}
 }
 
-// Chaining (the first middleware to set wins; later ones are no-ops)
+// Chaining: each ClientIPFrom* middleware always runs and overwrites if it
+// finds a value; the last one with a value wins. To get primary+fallback
+// behavior, order is "fallback first, preferred last".
 func TestClientIPChaining(t *testing.T) {
-	t.Run("header_wins_over_xff", func(t *testing.T) {
+	// Preferred middleware runs LAST and overrides the fallback.
+	t.Run("header_overrides_xff_when_set", func(t *testing.T) {
 		got := runChain(t,
 			[]func(http.Handler) http.Handler{
-				ClientIPFromHeader("CF-Connecting-IP"),
-				ClientIPFromXFF(),
+				ClientIPFromXFF(),                      // fallback.
+				ClientIPFromHeader("CF-Connecting-IP"), // preferred.
 			},
 			func(r *http.Request) {
 				r.Header.Set("CF-Connecting-IP", "1.1.1.1")
@@ -264,33 +267,35 @@ func TestClientIPChaining(t *testing.T) {
 		}
 	})
 
-	t.Run("xff_falls_through_to_remoteaddr", func(t *testing.T) {
+	// Preferred middleware finds nothing, so the fallback's value persists.
+	t.Run("xff_persists_when_header_missing", func(t *testing.T) {
 		got := runChain(t,
 			[]func(http.Handler) http.Handler{
-				ClientIPFromXFF("10.0.0.0/8"),
-				ClientIPFromRemoteAddr,
-			},
-			func(r *http.Request) {
-				// XFF contains only trusted values → no IP set by ClientIPFromXFF.
-				r.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
-				r.RemoteAddr = "192.0.2.1:1234"
-			})
-		if got != "192.0.2.1" {
-			t.Errorf("want 192.0.2.1 (RemoteAddr fallback), got %q", got)
-		}
-	})
-
-	t.Run("missing_header_falls_through_to_xff", func(t *testing.T) {
-		got := runChain(t,
-			[]func(http.Handler) http.Handler{
-				ClientIPFromHeader("CF-Connecting-IP"),
 				ClientIPFromXFF(),
+				ClientIPFromHeader("CF-Connecting-IP"), // missing → no-op.
 			},
 			func(r *http.Request) {
 				r.Header.Set("X-Forwarded-For", "8.8.8.8")
 			})
 		if got != "8.8.8.8" {
-			t.Errorf("want 8.8.8.8 (XFF fallback), got %q", got)
+			t.Errorf("want 8.8.8.8, got %q", got)
+		}
+	})
+
+	// RemoteAddr as last-resort baseline; XFF would override but finds only
+	// trusted IPs, so the baseline persists.
+	t.Run("remoteaddr_fills_in_when_xff_finds_nothing", func(t *testing.T) {
+		got := runChain(t,
+			[]func(http.Handler) http.Handler{
+				ClientIPFromRemoteAddr,
+				ClientIPFromXFF("10.0.0.0/8"), // all trusted → no-op.
+			},
+			func(r *http.Request) {
+				r.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
+				r.RemoteAddr = "192.0.2.1:1234"
+			})
+		if got != "192.0.2.1" {
+			t.Errorf("want 192.0.2.1, got %q", got)
 		}
 	})
 }

--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -31,6 +31,11 @@ func TestClientIPFromHeader(t *testing.T) {
 		{"private_v4_accepted", "10.0.1.10", "10.0.1.10"},
 		{"private_v6_accepted", "fc00::1", "fc00::1"},
 		{"unspecified_accepted", "0.0.0.0", "0.0.0.0"},
+
+		// Normalization: v4-mapped IPv6 folds to plain v4, IPv6 zone is stripped.
+		// Same logical client → same canonical string regardless of upstream notation.
+		{"v4_mapped_ipv6_folded_to_v4", "::ffff:1.2.3.4", "1.2.3.4"},
+		{"ipv6_zone_stripped", "2001:db8::1%eth0", "2001:db8::1"},
 	}
 
 	for _, tc := range tt {
@@ -63,6 +68,10 @@ func TestClientIPFromXFF_NoTrustedPrefixes(t *testing.T) {
 		{"ipv6", []string{"2001:db8::1"}, "2001:db8::1"},
 		{"mixed_v4_v6_rightmost_wins", []string{"203.0.113.1, 2001:db8::1"}, "2001:db8::1"},
 		{"unparseable_rightmost_skipped", []string{"1.1.1.1, garbage"}, "1.1.1.1"},
+
+		// Normalization at the entry point: v4-mapped IPv6 folds to v4, zone stripped.
+		{"v4_mapped_rightmost_folded", []string{"::ffff:1.2.3.4"}, "1.2.3.4"},
+		{"zone_stripped_rightmost", []string{"2001:db8::1%eth0"}, "2001:db8::1"},
 
 		// A header like "oh, hi,,127.0.0.1,,,," can be injected by the client.
 		// See https://adam-p.ca/blog/2022/03/x-forwarded-for/ for more details.
@@ -199,6 +208,16 @@ func TestClientIPFromXFFTrustedProxies(t *testing.T) {
 
 		// Merging across multiple header instances.
 		{"multi_header", 2, []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}, "2.2.2.2"},
+
+		// Empty entries dropped by mergeXFF must not shift the slot index. The
+		// slot is computed from the right, where trusted proxies append, so an
+		// attacker prepending commas can't slide their chosen value into the
+		// trusted slot.
+		{"empties_dont_shift_slot", 2, []string{",,, 3.3.3.3, 1.1.1.1, 2.2.2.2"}, "1.1.1.1"},
+
+		// Normalization at the chosen slot: v4-mapped IPv6 folds to v4, zone stripped.
+		{"v4_mapped_at_slot_folded", 1, []string{"::ffff:1.2.3.4"}, "1.2.3.4"},
+		{"zone_stripped_at_slot", 1, []string{"2001:db8::1%eth0"}, "2001:db8::1"},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -96,6 +96,8 @@ type DefaultLogFormatter struct {
 
 // NewLogEntry creates a new LogEntry for the request.
 func (l *DefaultLogFormatter) NewLogEntry(r *http.Request) LogEntry {
+	ctx := r.Context()
+
 	useColor := !l.NoColor
 	entry := &defaultLogEntry{
 		DefaultLogFormatter: l,
@@ -104,7 +106,7 @@ func (l *DefaultLogFormatter) NewLogEntry(r *http.Request) LogEntry {
 		useColor:            useColor,
 	}
 
-	reqID := GetReqID(r.Context())
+	reqID := GetReqID(ctx)
 	if reqID != "" {
 		cW(entry.buf, useColor, nYellow, "[%s] ", reqID)
 	}
@@ -118,7 +120,11 @@ func (l *DefaultLogFormatter) NewLogEntry(r *http.Request) LogEntry {
 	cW(entry.buf, useColor, nCyan, "%s://%s%s %s\" ", scheme, r.Host, r.RequestURI, r.Proto)
 
 	entry.buf.WriteString("from ")
-	entry.buf.WriteString(r.RemoteAddr)
+	clientIP := GetClientIP(ctx)
+	if clientIP == "" {
+		clientIP = r.RemoteAddr
+	}
+	entry.buf.WriteString(clientIP)
 	entry.buf.WriteString(" - ")
 
 	return entry

--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -17,17 +17,17 @@ var xRealIP = http.CanonicalHeaderKey("X-Real-IP")
 // of parsing either the True-Client-IP, X-Real-IP or the X-Forwarded-For headers
 // (in that order).
 //
-// This middleware should be inserted fairly early in the middleware stack to
-// ensure that subsequent layers (e.g., request loggers) which examine the
-// RemoteAddr will see the intended value.
+// Deprecated: RealIP is vulnerable to IP spoofing in any deployment where it
+// can be reached by a client able to set these headers (see GHSA-3fxj-6jh8-hvhx,
+// GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf). It blindly takes the leftmost
+// X-Forwarded-For value (trivially spoofable) and also trusts True-Client-IP
+// and X-Real-IP whether or not your infrastructure actually sets them.
 //
-// You should only use this middleware if you can trust the headers passed to
-// you (in particular, the three headers this middleware uses), for example
-// because you have placed a reverse proxy like HAProxy or nginx in front of
-// chi. If your reverse proxies are configured to pass along arbitrary header
-// values from the client, or if you use this middleware without a reverse
-// proxy, malicious clients will be able to make you very sad (or, depending on
-// how you're using RemoteAddr, vulnerable to an attack of some sort).
+// Use one of [ClientIPFromHeader], [ClientIPFromXFF],
+// [ClientIPFromXFFTrustedProxies] or [ClientIPFromRemoteAddr] instead — pick
+// exactly one based on your network setup — and read the resulting IP with
+// [GetClientIP] or [GetClientIPAddr]. Unlike RealIP, these never mutate
+// r.RemoteAddr.
 func RealIP(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		if rip := realIP(r); rip != "" {

--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -17,17 +17,14 @@ var xRealIP = http.CanonicalHeaderKey("X-Real-IP")
 // of parsing either the True-Client-IP, X-Real-IP or the X-Forwarded-For headers
 // (in that order).
 //
-// Deprecated: RealIP is vulnerable to IP spoofing in any deployment where it
-// can be reached by a client able to set these headers (see GHSA-3fxj-6jh8-hvhx,
-// GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf). It blindly takes the leftmost
-// X-Forwarded-For value (trivially spoofable) and also trusts True-Client-IP
-// and X-Real-IP whether or not your infrastructure actually sets them.
+// Deprecated: RealIP is vulnerable to IP spoofing — it mutates r.RemoteAddr
+// to the leftmost X-Forwarded-For value, or to True-Client-IP / X-Real-IP
+// whether or not your infrastructure actually sets them. See
+// GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf.
 //
-// Use one of [ClientIPFromHeader], [ClientIPFromXFF],
-// [ClientIPFromXFFTrustedProxies] or [ClientIPFromRemoteAddr] instead — pick
-// exactly one based on your network setup — and read the resulting IP with
-// [GetClientIP] or [GetClientIPAddr]. Unlike RealIP, these never mutate
-// r.RemoteAddr.
+// Use [ClientIPFromHeader], [ClientIPFromXFF], [ClientIPFromXFFTrustedProxies]
+// or [ClientIPFromRemoteAddr] and read the IP with [GetClientIP] instead.
+// These never mutate r.RemoteAddr.
 func RealIP(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		if rip := realIP(r); rip != "" {


### PR DESCRIPTION
A replacement for `middleware.RealIP` that closes the three open spoofing advisories against it:
- [GHSA-9g5q-2w5x-hmxf](https://github.com/go-chi/chi/security/advisories/GHSA-9g5q-2w5x-hmxf) — IP spoofing via XFF in `RemoteAddr` resolution (convto)
- [GHSA-rjr7-jggh-pgcp](https://github.com/go-chi/chi/security/advisories/GHSA-rjr7-jggh-pgcp) — RealIP allows IP spoofing via unvalidated XFF (rezmoss)
- [GHSA-3fxj-6jh8-hvhx](https://github.com/go-chi/chi/security/advisories/GHSA-3fxj-6jh8-hvhx) — IP spoofing in `middleware.RealIP` (Saku0512, Critical / 9.3)

It also addresses issues outlined at:
- https://github.com/go-chi/chi/issues/708
- https://adam-p.ca/blog/2022/03/x-forwarded-for/
- https://github.com/go-chi/chi/issues/711
- https://github.com/go-chi/chi/issues/453
- https://github.com/go-chi/chi/pull/908

`middleware.RealIP` is deprecated in this PR with pointers to the new API.

The deprecation only adds a `// Deprecated:` doc comment; the function keeps working for backward compatibility.

### Why a new middleware (not "fix RealIP in place")
`RealIP` has two unfixable design choices: it mutates `r.RemoteAddr`, and it tries to be a one-size-fits-all default by walking a hard-coded list of headers any client can supply. Per [adam-p's "The perils of the 'real' client IP"](https://adam-p.ca/blog/2022/03/x-forwarded-for/) (which calls chi out by name on this), there is no safe default — the user must pick their trust source explicitly.

### The new API
Four middlewares, two accessors. Pick exactly one middleware based on your
infrastructure, read the result with one of the two accessors:

```go
// One of the four. There is no safe default — pick exactly one.
func ClientIPFromHeader(trustedHeader string) func(http.Handler) http.Handler
func ClientIPFromXFF(trustedIPPrefixes ...string) func(http.Handler) http.Handler
func ClientIPFromXFFTrustedProxies(numTrustedProxies int) func(http.Handler) http.Handler
func ClientIPFromRemoteAddr(h http.Handler) http.Handler

// Read the result.
func GetClientIP(ctx context.Context) string         // for logs, rate-limit keys
func GetClientIPAddr(ctx context.Context) netip.Addr // for typed work
```

## Example usage:
```go
// Pick a single ClientIP middleware based on your deployment
  
// Cloudflare.
r.Use(middleware.ClientIPFromHeader("CF-Connecting-IP"))

// Nginx with ngx_http_realip_module.
r.Use(middleware.ClientIPFromHeader("X-Real-IP"))

// Apache with mod_remoteip.
r.Use(middleware.ClientIPFromHeader("X-Client-IP"))

// AWS CloudFront, or any proxy fleet with known CIDRs.
r.Use(middleware.ClientIPFromXFF(
    "13.32.0.0/15",   // CloudFront IPv4
    "52.46.0.0/18",   // CloudFront IPv4
    "2600:9000::/28", // CloudFront IPv6
))

// Behind exactly 2 trusted proxies with dynamic IPs (autoscaling pools,
// ephemeral containers, dynamic CDN edges).
r.Use(middleware.ClientIPFromXFFTrustedProxies(2))

// Server directly on the public internet, no proxy in front.
r.Use(middleware.ClientIPFromRemoteAddr)
```

And in your handler or downstream middleware:
```go
clientIP := middleware.GetClientIP(r.Context())
// log it, use it as a rate-limit key, etc.
```
---

Thanks to @adam-p, @c2h5oh, @rezmoss, @Saku0512, @convto, @Dirbaio, @jawnsy, @lrstanley, @mfridman, @n33pm, @pkieltyka for the prior discussions, detailed reviews, advisory reports, and test contributions that shaped this PR.
