### PR TITLE
feat:() creating a new BasicMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ func main() {
   r.Use(middleware.RealIP)
   r.Use(middleware.Logger)
   r.Use(middleware.Recoverer)
-
+  // or you can use
+  middleware.BasicMiddlewares()
+  
   // Set a timeout value on the request context (ctx), that will signal
   // through ctx.Done() that the request has timed out and further
   // processing should be stopped.

--- a/middleware/basic_middlewares.go
+++ b/middleware/basic_middlewares.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"github.com/go-chi/chi/v5"
+)
+
+// BasicMiddlewares offers a good base middleware stack,
+// includes middleware.Logger, middleware.Recoverer, middleware.RequestID and middleware.RealIP
+func BasicMiddlewares(r *chi.Mux) {
+
+	r.Use(Logger)
+	r.Use(Recoverer)
+	r.Use(RequestID)
+	r.Use(RealIP)
+
+}


### PR DESCRIPTION
I grouped middleware.RequestID, middleware.Logger, middleware.Recoverer, and middleware.RealIP into a single function called BasicMiddleware to simplify the process. Instead of adding each middleware individually, you can just call BasicMiddleware, and it works seamlessly! I also Updated the Readme.MD to show how to use this new function.