### PR TITLE
Use strings.Cut in a few places

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -277,16 +277,13 @@ type compressResponseWriter struct {
 func (cw *compressResponseWriter) isCompressible() bool {
 	// Parse the first part of the Content-Type response header.
 	contentType := cw.Header().Get("Content-Type")
-	if idx := strings.Index(contentType, ";"); idx >= 0 {
-		contentType = contentType[0:idx]
-	}
+	contentType, _, _ = strings.Cut(contentType, ";")
 
 	// Is the content type compressible?
 	if _, ok := cw.contentTypes[contentType]; ok {
 		return true
 	}
-	if idx := strings.Index(contentType, "/"); idx > 0 {
-		contentType = contentType[0:idx]
+	if contentType, _, hadSlash := strings.Cut(contentType, "/"); hadSlash {
 		_, ok := cw.contentWildcards[contentType]
 		return ok
 	}

--- a/middleware/realip.go
+++ b/middleware/realip.go
@@ -47,11 +47,7 @@ func realIP(r *http.Request) string {
 	} else if xrip := r.Header.Get(xRealIP); xrip != "" {
 		ip = xrip
 	} else if xff := r.Header.Get(xForwardedFor); xff != "" {
-		i := strings.Index(xff, ",")
-		if i == -1 {
-			i = len(xff)
-		}
-		ip = xff[:i]
+		ip, _, _ = strings.Cut(xff, ",")
 	}
 	if ip == "" || net.ParseIP(ip) == nil {
 		return ""

--- a/middleware/route_headers.go
+++ b/middleware/route_headers.go
@@ -133,13 +133,7 @@ type Pattern struct {
 
 func NewPattern(value string) Pattern {
 	p := Pattern{}
-	if i := strings.IndexByte(value, '*'); i >= 0 {
-		p.wildcard = true
-		p.prefix = value[0:i]
-		p.suffix = value[i+1:]
-	} else {
-		p.prefix = value
-	}
+	p.prefix, p.suffix, p.wildcard = strings.Cut(value, "*")
 	return p
 }
 

--- a/tree.go
+++ b/tree.go
@@ -730,11 +730,9 @@ func patNextSegment(pattern string) (nodeTyp, string, string, byte, int, int) {
 			tail = pattern[pe]
 		}
 
-		var rexpat string
-		if idx := strings.Index(key, ":"); idx >= 0 {
+		key, rexpat, isRegexp := strings.Cut(key, ":")
+		if isRegexp {
 			nt = ntRegexp
-			rexpat = key[idx+1:]
-			key = key[:idx]
 		}
 
 		if len(rexpat) > 0 {


### PR DESCRIPTION
Now that we're 1.20+ instead of 1.14+ we can use 1.18's strings.Cut in a few places to simplify code.