### PR TITLE
replace hardcoded methods and statuses with standard constants

### DIFF
--- a/middleware/content_type.go
+++ b/middleware/content_type.go
@@ -42,4 +42,3 @@ func AllowContentType(contentTypes ...string) func(http.Handler) http.Handler {
 		})
 	}
 }
-

--- a/middleware/get_head.go
+++ b/middleware/get_head.go
@@ -9,7 +9,7 @@ import (
 // GetHead automatically route undefined HEAD requests to GET handlers.
 func GetHead(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "HEAD" {
+		if r.Method == http.MethodHead {
 			rctx := chi.RouteContext(r.Context())
 			routePath := rctx.RoutePath
 			if routePath == "" {
@@ -26,8 +26,8 @@ func GetHead(next http.Handler) http.Handler {
 			// Attempt to find a HEAD handler for the routing path, if not found, traverse
 			// the router as through its a GET route, but proceed with the request
 			// with the HEAD method.
-			if !rctx.Routes.Match(tctx, "HEAD", routePath) {
-				rctx.RouteMethod = "GET"
+			if !rctx.Routes.Match(tctx, http.MethodHead, routePath) {
+				rctx.RouteMethod = http.MethodGet
 				rctx.RoutePath = routePath
 				next.ServeHTTP(w, r)
 				return

--- a/middleware/heartbeat.go
+++ b/middleware/heartbeat.go
@@ -12,7 +12,7 @@ import (
 func Heartbeat(endpoint string) func(http.Handler) http.Handler {
 	f := func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			if (r.Method == "GET" || r.Method == "HEAD") && strings.EqualFold(r.URL.Path, endpoint) {
+			if (r.Method == http.MethodGet || r.Method == http.MethodHead) && strings.EqualFold(r.URL.Path, endpoint) {
 				w.Header().Set("Content-Type", "text/plain")
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte("."))

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -133,13 +133,13 @@ type defaultLogEntry struct {
 
 func (l *defaultLogEntry) Write(status, bytes int, header http.Header, elapsed time.Duration, extra interface{}) {
 	switch {
-	case status < 200:
+	case status < http.StatusOK:
 		cW(l.buf, l.useColor, bBlue, "%03d", status)
-	case status < 300:
+	case status < http.StatusMultipleChoices:
 		cW(l.buf, l.useColor, bGreen, "%03d", status)
-	case status < 400:
+	case status < http.StatusBadRequest:
 		cW(l.buf, l.useColor, bCyan, "%03d", status)
-	case status < 500:
+	case status < http.StatusInternalServerError:
 		cW(l.buf, l.useColor, bYellow, "%03d", status)
 	default:
 		cW(l.buf, l.useColor, bRed, "%03d", status)

--- a/middleware/page_route.go
+++ b/middleware/page_route.go
@@ -10,7 +10,7 @@ import (
 func PageRoute(path string, handler http.Handler) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == "GET" && strings.EqualFold(r.URL.Path, path) {
+			if r.Method == http.MethodGet && strings.EqualFold(r.URL.Path, path) {
 				handler.ServeHTTP(w, r)
 				return
 			}


### PR DESCRIPTION
Somewhere in the newer code constants from the net/http package are used, and in some of the old code hardcoded values.
I suggest replacing the hardcoded values ​​with constants.