### PR TITLE
Exclude middleware/profiler.go in TinyGo, as there's no net/http/pprof pkg

### DIFF
--- a/middleware/profiler.go
+++ b/middleware/profiler.go
@@ -1,3 +1,6 @@
+//go:build !tinygo
+// +build !tinygo
+
 package middleware
 
 import (


### PR DESCRIPTION
when I want to use middleware in tinygo, it will failed because of `https://github.com/go-chi/chi/blob/master/middleware/profiler.go`, there is no package `net/http/pprof` for tinygo.
```
	r := chi.NewRouter()
	r.Use(middleware.CleanPath)
	r.Use(middleware.RealIP)
	r.Use(middleware.Logger)
	r.Use(middleware.Recoverer)
```
error output:
```
../../../go/pkg/mod/github.com/go-chi/chi/v5@v5.2.1/middleware/profiler.go:6:2: 
package net/http/pprof is not in std (/Users/user/Library/Caches/tinygo/goroot-598d56643c1f2b0a17cb7ed7f5003addae1fc3ee5af904a1c5356bb7118a4988/src/net/http/pprof)
```
we need to exclude `middleware/profiler.go` when use tinygo.