### PR TITLE
Add pathvalue example to README and implement PathValue handler.

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -12,6 +12,7 @@ chi examples
 * [router-walk](https://github.com/go-chi/chi/blob/master/_examples/router-walk/main.go) - Print to stdout a router's routes
 * [todos-resource](https://github.com/go-chi/chi/blob/master/_examples/todos-resource/main.go) - Struct routers/handlers, an example of another code layout style
 * [versions](https://github.com/go-chi/chi/blob/master/_examples/versions/main.go) - Demo of `chi/render` subpkg
+* [pathvalue](https://github.com/go-chi/chi/blob/master/_examples/pathvalue/main.go) - Demonstrates `PathValue` usage for retrieving URL parameters
 
 
 ## Usage

--- a/_examples/pathvalue/main.go
+++ b/_examples/pathvalue/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func main() {
+	r := chi.NewRouter()
+
+	// Registering a handler that retrieves a path parameter using PathValue
+	r.Get("/users/{userID}", pathValueHandler)
+
+	http.ListenAndServe(":3333", r)
+}
+
+// pathValueHandler retrieves a URL parameter using PathValue and writes it to the response.
+func pathValueHandler(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("userID")
+
+	// Respond with the extracted userID
+	w.Write([]byte(fmt.Sprintf("User ID: %s", userID)))
+}


### PR DESCRIPTION
This pull request includes updates to the `chi` examples, specifically adding a new example that demonstrates the usage of `PathValue` for retrieving URL parameters. The most important changes include the addition of a new example in the `_examples/README.md` file and the implementation of the `pathvalue` example in a new Go file.

New example addition:

* [`_examples/README.md`](diffhunk://#diff-f370007ac2f128eca652bd2acedeb98c49ad44e517ac7c8a9294668a7acb4bd1R15): Added a new entry for the `pathvalue` example, which demonstrates the usage of `PathValue` for retrieving URL parameters.

Implementation of the `pathvalue` example:

* [`_examples/pathvalue/main.go`](diffhunk://#diff-61eb4288dd3426b953600ac17e2cb836aa7b6855ae09f0c47f9ead6016400038R1-R25): Created a new Go file that includes a router setup with a handler to retrieve and respond with a URL parameter using `PathValue`.

refs: #984