### PR TITLE
Change install command format to code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ and [docgen](https://github.com/go-chi/docgen). We hope you enjoy it too!
 
 ## Install
 
-`go get -u github.com/go-chi/chi/v5`
+```sh
+go get -u github.com/go-chi/chi/v5
+```
 
 
 ## Features


### PR DESCRIPTION
Improves developer experience by changing the install command format from single backtick (code) to double backticks (code block), providing copy to clipboard button.