### PR TITLE
Make use of strings.Cut

### DIFF
--- a/middleware/content_charset.go
+++ b/middleware/content_charset.go
@@ -40,11 +40,10 @@ func contentEncoding(ce string, charsets ...string) bool {
 
 // Split a string in two parts, cleaning any whitespace.
 func split(str, sep string) (string, string) {
-	var a, b string
-	var parts = strings.SplitN(str, sep, 2)
-	a = strings.TrimSpace(parts[0])
-	if len(parts) == 2 {
-		b = strings.TrimSpace(parts[1])
+	a, b, found := strings.Cut(str, sep)
+	a = strings.TrimSpace(a)
+	if found {
+		b = strings.TrimSpace(b)
 	}
 
 	return a, b

--- a/middleware/content_type.go
+++ b/middleware/content_type.go
@@ -31,7 +31,8 @@ func AllowContentType(contentTypes ...string) func(http.Handler) http.Handler {
 				return
 			}
 
-			s := strings.ToLower(strings.TrimSpace(strings.Split(r.Header.Get("Content-Type"), ";")[0]))
+			s, _, _ := strings.Cut(r.Header.Get("Content-Type"), ";")
+			s = strings.ToLower(strings.TrimSpace(s))
 
 			if _, ok := allowedContentTypes[s]; ok {
 				next.ServeHTTP(w, r)
@@ -42,4 +43,3 @@ func AllowContentType(contentTypes ...string) func(http.Handler) http.Handler {
 		})
 	}
 }
-

--- a/mux.go
+++ b/mux.go
@@ -107,9 +107,8 @@ func (mx *Mux) Use(middlewares ...func(http.Handler) http.Handler) {
 // Handle adds the route `pattern` that matches any http method to
 // execute the `handler` http.Handler.
 func (mx *Mux) Handle(pattern string, handler http.Handler) {
-	parts := strings.SplitN(pattern, " ", 2)
-	if len(parts) == 2 {
-		mx.Method(parts[0], parts[1], handler)
+	if method, rest, found := strings.Cut(pattern, " "); found {
+		mx.Method(method, rest, handler)
 		return
 	}
 
@@ -119,9 +118,8 @@ func (mx *Mux) Handle(pattern string, handler http.Handler) {
 // HandleFunc adds the route `pattern` that matches any http method to
 // execute the `handlerFn` http.HandlerFunc.
 func (mx *Mux) HandleFunc(pattern string, handlerFn http.HandlerFunc) {
-	parts := strings.SplitN(pattern, " ", 2)
-	if len(parts) == 2 {
-		mx.Method(parts[0], parts[1], handlerFn)
+	if method, rest, found := strings.Cut(pattern, " "); found {
+		mx.Method(method, rest, handlerFn)
 		return
 	}
 


### PR DESCRIPTION
For cleanliness, likely small performance improvement and fewer allocations.