### PR TITLE
Update compress middleware support Brotli support documentation

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -136,13 +136,11 @@ func NewCompressor(level int, types ...string) *Compressor {
 //
 // For example, add the Brotli algorithm:
 //
-//	import brotli_enc "gopkg.in/kothar/brotli-go.v0/enc"
+//	"github.com/google/brotli/go/cbrotli"
 //
 //	compressor := middleware.NewCompressor(5, "text/html")
 //	compressor.SetEncoder("br", func(w io.Writer, level int) io.Writer {
-//		params := brotli_enc.NewBrotliParams()
-//		params.SetQuality(level)
-//		return brotli_enc.NewBrotliWriter(params, w)
+//		return cbrotli.NewWriter(w, cbrotli.WriterOptions{Quality: level})
 //	})
 func (c *Compressor) SetEncoder(encoding string, fn EncoderFunc) {
 	encoding = strings.ToLower(encoding)

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -136,11 +136,21 @@ func NewCompressor(level int, types ...string) *Compressor {
 //
 // For example, add the Brotli algorithm:
 //
-//	"github.com/google/brotli/go/cbrotli"
+//	import "github.com/google/brotli/go/cbrotli"
 //
 //	compressor := middleware.NewCompressor(5, "text/html")
 //	compressor.SetEncoder("br", func(w io.Writer, level int) io.Writer {
 //		return cbrotli.NewWriter(w, cbrotli.WriterOptions{Quality: level})
+//	})
+//
+// Alternatively, this Cgo-free Brotli module can be used:
+//
+//	import "github.com/andybalholm/brotli"
+//
+//	compressor := middleware.NewCompressor(5, "text/html")
+//
+//	compressor.SetEncoder("br", func(w io.Writer, level int) io.Writer {
+//		return brotli.NewWriterV2(w, level)
 //	})
 func (c *Compressor) SetEncoder(encoding string, fn EncoderFunc) {
 	encoding = strings.ToLower(encoding)

--- a/path_value.go
+++ b/path_value.go
@@ -1,7 +1,6 @@
 //go:build go1.22 && !tinygo
 // +build go1.22,!tinygo
 
-
 package chi
 
 import "net/http"

--- a/path_value.go
+++ b/path_value.go
@@ -1,6 +1,7 @@
 //go:build go1.22 && !tinygo
 // +build go1.22,!tinygo
 
+
 package chi
 
 import "net/http"


### PR DESCRIPTION
### What
Update inline documentation on how to add Brotli support to a compress middleware instance.

### Why
The code sample in the current documentation is referencing a Brotli package that has been archived more than 5 years ago.

### How
Update the documentation to the use the Google's "reference" implementation Go module (github.com/google/brotli/go/cbrotli). PR also documents an alternative approach using a Cgo-free module, which can be easier to deal with if performance is not an absolute priority. Both modules are being actively maintained.