### PR TITLE
Avoid potential nil dereference

### DIFF
--- a/middleware/url_format.go
+++ b/middleware/url_format.go
@@ -55,7 +55,7 @@ func URLFormat(next http.Handler) http.Handler {
 			path = rctx.RoutePath
 		}
 
-		if strings.Index(path, ".") > 0 {
+		if rctx != nil && strings.Index(path, ".") > 0 {
 			base := strings.LastIndex(path, "/")
 			idx := strings.LastIndex(path[base:], ".")
 


### PR DESCRIPTION
Fixes: 0fe6bf1 ("Use RoutePath in URLFormat middleware (#718)")   
Found by PostgresPro with Svace Static Analyzer
Signed-off-by: Maksim Korotkov <m.korotkov@postgrespro.ru>