### PR TITLE
fix(compress): If it's not compressible, there's no need to write to the close …

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -365,6 +365,9 @@ func (cw *compressResponseWriter) Push(target string, opts *http.PushOptions) er
 }
 
 func (cw *compressResponseWriter) Close() error {
+	if !cw.compressible {
+		return nil
+	}
 	if c, ok := cw.writer().(io.WriteCloser); ok {
 		return c.Close()
 	}


### PR DESCRIPTION
If it's not compressible, there's no need to write to the close  buf.