### PR TITLE
Optimize throttle middleware by avoiding unnecessary timer creation

### DIFF
--- a/middleware/throttle_test.go
+++ b/middleware/throttle_test.go
@@ -299,3 +299,20 @@ func TestThrottleCustomStatusCode(t *testing.T) {
 	close(wait) // Allow the last request to proceed.
 	waitResponse(http.StatusOK)
 }
+
+func BenchmarkThrottle(b *testing.B) {
+	throttleMiddleware := ThrottleBacklog(1000, 50, time.Second)
+
+	handler := throttleMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+}


### PR DESCRIPTION
- Only create time.NewTimer() when actually needed to wait
- Reduces allocations from 7 to 4 and memory usage by ~54%
- Improves performance by ~50% in high-throughput scenarios

**Benchmark results:**

Before:
```
goos: darwin
goarch: arm64
pkg: github.com/go-chi/chi/v5/middleware
cpu: Apple M1 Max
BenchmarkThrottle
BenchmarkThrottle-10    	 3349486	       382.3 ns/op	     456 B/op	       7 allocs/op
PASS
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/go-chi/chi/v5/middleware
cpu: Apple M1 Max
BenchmarkThrottle
BenchmarkThrottle-10    	 6310284	       186.9 ns/op	     208 B/op	       4 allocs/op
PASS
```