### PR TITLE
Simplify wildcard replacement in route patterns

### DIFF
--- a/context.go
+++ b/context.go
@@ -133,11 +133,12 @@ func (x *Context) RoutePattern() string {
 	return routePattern
 }
 
-// replaceWildcards takes a route pattern and recursively replaces all
-// occurrences of "/*/" to "/".
+// replaceWildcards takes a route pattern and replaces all occurrences of
+// "/*/" with "/". It iteratively runs until no wildcards remain to
+// correctly handle consecutive wildcards.
 func replaceWildcards(p string) string {
-	if strings.Contains(p, "/*/") {
-		return replaceWildcards(strings.Replace(p, "/*/", "/", -1))
+	for strings.Contains(p, "/*/") {
+		p = strings.ReplaceAll(p, "/*/", "/")
 	}
 	return p
 }

--- a/context_test.go
+++ b/context_test.go
@@ -91,3 +91,14 @@ func TestRoutePattern(t *testing.T) {
 		t.Fatalf("unexpected non-empty route pattern for nil context: %q", p)
 	}
 }
+
+// TestReplaceWildcardsConsecutive ensures multiple consecutive wildcards are
+// collapsed into a single slash.
+func TestReplaceWildcardsConsecutive(t *testing.T) {
+	if p := replaceWildcards("/foo/*/*/*/bar"); p != "/foo/bar" {
+		t.Fatalf("unexpected wildcard replacement: %s", p)
+	}
+	if p := replaceWildcards("/foo/*/*/*/bar/*"); p != "/foo/bar/*" {
+		t.Fatalf("unexpected trailing wildcard behavior: %s", p)
+	}
+}


### PR DESCRIPTION
Replace recursive wildcard collapsing with iterative strings.ReplaceAll
Add tests for consecutive wildcard segments and trailing wildcard behavior
