### PR TITLE
Allow multiple whitespace between method & pattern

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -107,7 +107,8 @@ func (mx *Mux) Use(middlewares ...func(http.Handler) http.Handler) {
 // Handle adds the route `pattern` that matches any http method to
 // execute the `handler` http.Handler.
 func (mx *Mux) Handle(pattern string, handler http.Handler) {
-	if method, rest, found := strings.Cut(pattern, " "); found {
+	if i := strings.IndexAny(pattern, " \t"); i >= 0 {
+		method, rest := pattern[:i], strings.TrimLeft(pattern[i+1:], " \t")
 		mx.Method(method, rest, handler)
 		return
 	}
@@ -118,12 +119,7 @@ func (mx *Mux) Handle(pattern string, handler http.Handler) {
 // HandleFunc adds the route `pattern` that matches any http method to
 // execute the `handlerFn` http.HandlerFunc.
 func (mx *Mux) HandleFunc(pattern string, handlerFn http.HandlerFunc) {
-	if method, rest, found := strings.Cut(pattern, " "); found {
-		mx.Method(method, rest, handlerFn)
-		return
-	}
-
-	mx.handle(mALL, pattern, handlerFn)
+	mx.Handle(pattern, handlerFn)
 }
 
 // Method adds the route `pattern` that matches `method` http method to

--- a/mux_test.go
+++ b/mux_test.go
@@ -668,6 +668,15 @@ func TestMuxHandlePatternValidation(t *testing.T) {
 			expectedBody:   "with-prefix POST",
 			expectedStatus: http.StatusOK,
 		},
+		{
+			name:           "Valid pattern with multiple whitespace after method",
+			pattern:        "PATCH \t /",
+			shouldPanic:    false,
+			method:         "PATCH",
+			path:           "/",
+			expectedBody:   "extended-whitespace PATCH",
+			expectedStatus: http.StatusOK,
+		},
 		// Invalid patterns
 		{
 			name:        "Invalid pattern with no method",


### PR DESCRIPTION
Allow separating the method and pattern with `[ \t]+`, this matches the stdlib change that was made in https://github.com/golang/go/commit/7b583fd

The rationale is the same as the stdlib issue, it allows you to visually line up patterns with variable-width methods:
```
r.Handle("GET    /my-route", handler1)
r.Handle("POST   /my-route", handler2)
r.Handle("DELETE /my-route", handler3)
```
In general aligning ourselves with the stdlib brings less surprise for end users.