### PR TITLE
docs: clarify With() middleware comment

### DIFF
--- a/chi.go
+++ b/chi.go
@@ -70,7 +70,8 @@ type Router interface {
 	// Use appends one or more middlewares onto the Router stack.
 	Use(middlewares ...func(http.Handler) http.Handler)
 
-	// With adds inline middlewares for an endpoint handler.
+	// With adds inline middlewares for an endpoint handler,
+	// applying them only to the specific route(s) defined on it.
 	With(middlewares ...func(http.Handler) http.Handler) Router
 
 	// Group adds a new inline-Router along the current routing


### PR DESCRIPTION
The original comment: // With adds inline middlewares for an endpoint handler. 

this does not indicate that the middleware is applied only to specific routes. It only states that the middleware is added to an endpoint handler, so it is not clear whether it affects all routes or just a subset. Adding "applying them only to the specific route(s) defined on it" makes this behavior explicit and easier for developers to understand.