### PR TITLE
Add ability to poison contexts, preventing reuse

### DIFF
--- a/context.go
+++ b/context.go
@@ -76,6 +76,12 @@ type Context struct {
 
 	methodsAllowed   []methodTyp // allowed methods in case of a 405
 	methodNotAllowed bool
+	poisoned         bool // prevents returning to pool
+}
+
+// PreventReuse marks the routing context as being unable to be returned to the pool.
+func (x *Context) PreventReuse() {
+	x.poisoned = true
 }
 
 // Reset a routing context to its initial state.

--- a/context.go
+++ b/context.go
@@ -79,7 +79,8 @@ type Context struct {
 	poisoned         bool // prevents returning to pool
 }
 
-// PreventReuse marks the routing context as being unable to be returned to the pool.
+// PreventReuse marks the Context as being unable to be returned to the pool
+// and allowing it to be safely used outside of the running request.
 func (x *Context) PreventReuse() {
 	x.poisoned = true
 }

--- a/mux.go
+++ b/mux.go
@@ -88,7 +88,10 @@ func (mx *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Serve the request and once its done, put the request context back in the sync pool
 	mx.handler.ServeHTTP(w, r)
-	mx.pool.Put(rctx)
+
+	if !rctx.poisoned {
+		mx.pool.Put(rctx)
+	}
 }
 
 // Use appends a middleware handler to the Mux middleware stack.


### PR DESCRIPTION
I’m working with several teams to extract new services, replacing existing API endpoints one by one. To validate these changes we're comparing responses from the legacy ("control") service against the new ("candidate") service. We initially started implementing this in `chi`, but ran into race conditions due to `sync.Pool` reusing `chi.Context` between requests. This is due to us returning the "control" response immediately, followed by calling the "candidate" response in the background (which utilizes `context`) outside of the original req/res lifecycle.

We have some workarounds in place, but ideally chi would allow more control over context reuse for this use-case. I took a pretty basic swing at this, implementing a new `PreventReuse()` method on `Context` that marks the `Context` as `poisoned` and avoiding the `sync.Pool.Put` call appropriately.

I totally understand if this is out of scope or isn't an API you wanted to support, but I wanted to open a PR to get feedback and see if there's interest instead of assuming.

Either way, the good news here is that the new services are using chi. ;)