### PR TITLE
feat(compress): support new graphql json type by default

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -24,6 +24,7 @@ var defaultCompressibleContentTypes = []string{
 	"application/atom+xml",
 	"application/rss+xml",
 	"image/svg+xml",
+	"application/graphql-response+json",
 }
 
 // Compress is a middleware that compresses response

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -120,7 +120,7 @@ func TestCompressorWildcards(t *testing.T) {
 	}{
 		{
 			name:       "defaults",
-			typesCount: 10,
+			typesCount: 11,
 		},
 		{
 			name:       "no wildcard",


### PR DESCRIPTION
## Changes
The GraphQL over HTTP spec introduces a new `application/graphql-response+json` content type. While this is still in draft,  libraries like 99designs/gqlgen [have already switched to use this type by default.](https://github.com/99designs/gqlgen/blob/master/graphql/handler/transport/http_post.go#L18-L26) As the spec is implemented it will become preferred to use this type. It would be good to ensure this is supported by default to ensure that compression is not silently disabled in the default case as libraries are updated and begin to use this type.