### PR TITLE
Fix RouteHeaders middleware to handle Host header correctly

### DIFF
--- a/middleware/route_headers_test.go
+++ b/middleware/route_headers_test.go
@@ -1,0 +1,177 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRouteHeadersHostHeader(t *testing.T) {
+	// Test that the Host header is properly read from r.Host
+	// since Go's http server promotes it there and removes it from Header map
+
+	mainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("main"))
+	})
+
+	subdomainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("subdomain"))
+	})
+
+	// Create the route headers middleware
+	hr := RouteHeaders().
+		Route("Host", "*.example.com", func(next http.Handler) http.Handler {
+			return subdomainHandler
+		}).
+		Handler(mainHandler)
+
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{
+			name:     "subdomain match",
+			host:     "sub.example.com",
+			expected: "subdomain",
+		},
+		{
+			name:     "main domain no match",
+			host:     "example.com",
+			expected: "main",
+		},
+		{
+			name:     "other domain no match",
+			host:     "other.com",
+			expected: "main",
+		},
+		{
+			name:     "nested subdomain match",
+			host:     "deep.sub.example.com",
+			expected: "subdomain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.Host = tt.host
+
+			rec := httptest.NewRecorder()
+			hr.ServeHTTP(rec, req)
+
+			if rec.Body.String() != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRouteHeadersHostHeaderWithPort(t *testing.T) {
+	// Test that Host header with port is handled correctly
+
+	mainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("main"))
+	})
+
+	subdomainHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("subdomain"))
+	})
+
+	hr := RouteHeaders().
+		Route("Host", "*.example.com:8080", func(next http.Handler) http.Handler {
+			return subdomainHandler
+		}).
+		Handler(mainHandler)
+
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{
+			name:     "subdomain with port match",
+			host:     "sub.example.com:8080",
+			expected: "subdomain",
+		},
+		{
+			name:     "subdomain without port no match",
+			host:     "sub.example.com",
+			expected: "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.Host = tt.host
+
+			rec := httptest.NewRecorder()
+			hr.ServeHTTP(rec, req)
+
+			if rec.Body.String() != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRouteHeadersRegularHeader(t *testing.T) {
+	// Test that regular headers (not Host) still work from r.Header
+
+	defaultHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("default"))
+	})
+
+	matchedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("matched"))
+	})
+
+	hr := RouteHeaders().
+		Route("X-Custom-Header", "special-value", func(next http.Handler) http.Handler {
+			return matchedHandler
+		}).
+		Handler(defaultHandler)
+
+	tests := []struct {
+		name        string
+		headerKey   string
+		headerValue string
+		expected    string
+	}{
+		{
+			name:        "matching header",
+			headerKey:   "X-Custom-Header",
+			headerValue: "special-value",
+			expected:    "matched",
+		},
+		{
+			name:        "non-matching header value",
+			headerKey:   "X-Custom-Header",
+			headerValue: "other-value",
+			expected:    "default",
+		},
+		{
+			name:        "missing header",
+			headerKey:   "",
+			headerValue: "",
+			expected:    "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			if tt.headerKey != "" {
+				req.Header.Set(tt.headerKey, tt.headerValue)
+			}
+
+			rec := httptest.NewRecorder()
+			hr.ServeHTTP(rec, req)
+
+			if rec.Body.String() != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, rec.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Go's http server promotes the Host header to `r.Host` and removes it from the Header map. This means `r.Header.Get("Host")` always returns an empty string, making the Host-based routing example in `RouteHeaders` non-functional.

This change:
- Adds special handling for the "Host" header to read from `r.Host` instead of `r.Header.Get("Host")`
- Fixes the documentation example to avoid circular router references which would cause a stack overflow
- Adds comprehensive tests for Host header routing behavior

## Changes

1. **route_headers.go**: Added conditional check for "host" header to use `r.Host`
2. **route_headers.go**: Updated example code in comments to work correctly
3. **route_headers_test.go**: Added tests covering Host header routing with subdomains and ports

## Test Plan

- [x] All existing tests pass
- [x] New tests verify Host header is correctly read from `r.Host`
- [x] Tests cover subdomain matching with wildcards
- [x] Tests cover Host with port numbers

Fixes #691