### PR TITLE
Fix defaultLogEntry.Panic not respecting NoColor setting

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -160,7 +160,7 @@ func (l *defaultLogEntry) Write(status, bytes int, header http.Header, elapsed t
 }
 
 func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
-	PrintPrettyStack(v)
+	printPrettyStack(v, l.useColor)
 }
 
 func init() {

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -52,9 +52,13 @@ func Recoverer(next http.Handler) http.Handler {
 var recovererErrorWriter io.Writer = os.Stderr
 
 func PrintPrettyStack(rvr interface{}) {
+	printPrettyStack(rvr, true)
+}
+
+func printPrettyStack(rvr interface{}, useColor bool) {
 	debugStack := debug.Stack()
 	s := prettyStack{}
-	out, err := s.parse(debugStack, rvr)
+	out, err := s.parse(debugStack, rvr, useColor)
 	if err == nil {
 		recovererErrorWriter.Write(out)
 	} else {
@@ -66,9 +70,8 @@ func PrintPrettyStack(rvr interface{}) {
 type prettyStack struct {
 }
 
-func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
+func (s prettyStack) parse(debugStack []byte, rvr interface{}, useColor bool) ([]byte, error) {
 	var err error
-	useColor := true
 	buf := &bytes.Buffer{}
 
 	cW(buf, false, bRed, "\n")


### PR DESCRIPTION
`defaultLogEntry.Panic()` calls `PrintPrettyStack()` which hardcodes
`useColor = true`, ignoring the `NoColor` field on `DefaultLogFormatter`.

This threads the `useColor` flag from `defaultLogEntry` through to
`prettyStack.parse()`. The public `PrintPrettyStack` function keeps its
existing behavior (always colored).

Fixes #1042