### PR TITLE
Apply the stringscutprefix modernizer

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -70,8 +70,8 @@ func NewCompressor(level int, types ...string) *Compressor {
 			if strings.Contains(strings.TrimSuffix(t, "/*"), "*") {
 				panic(fmt.Sprintf("middleware/compress: Unsupported content-type wildcard pattern '%s'. Only '/*' supported", t))
 			}
-			if strings.HasSuffix(t, "/*") {
-				allowedWildcards[strings.TrimSuffix(t, "/*")] = struct{}{}
+			if before, ok := strings.CutSuffix(t, "/*"); ok {
+				allowedWildcards[before] = struct{}{}
 			} else {
 				allowedTypes[t] = struct{}{}
 			}


### PR DESCRIPTION
The stringscutprefix analyzer simplifies a common pattern where code first checks for a prefix with `strings.HasPrefix` and then removes it with `strings.TrimPrefix`. It replaces this two-step process with a single call to `strings.CutPrefix`, introduced in Go 1.20. The analyzer also handles the equivalent functions in the `bytes` package.

See https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_stringscutprefix