### PR TITLE
Simplify chi.walk with slices.Concat

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -836,9 +837,7 @@ func Walk(r Routes, walkFn WalkFunc) error {
 
 func walk(r Routes, walkFn WalkFunc, parentRoute string, parentMw ...func(http.Handler) http.Handler) error {
 	for _, route := range r.Routes() {
-		mws := make([]func(http.Handler) http.Handler, len(parentMw))
-		copy(mws, parentMw)
-		mws = append(mws, r.Middlewares()...)
+		mws := slices.Concat(parentMw, r.Middlewares())
 
 		if route.SubRoutes != nil {
 			if handler, ok := route.Handlers["*"]; ok {


### PR DESCRIPTION
Should perform better too as the initial allocation will be sized to fit both slices unlike before.