### PR TITLE
Remove last uses of io/ioutil

### DIFF
--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -207,7 +206,7 @@ func decodeResponseBody(t *testing.T, resp *http.Response) string {
 	default:
 		reader = resp.Body
 	}
-	respBody, err := ioutil.ReadAll(reader)
+	respBody, err := io.ReadAll(reader)
 	if err != nil {
 		t.Fatal(err)
 		return ""

--- a/middleware/throttle_test.go
+++ b/middleware/throttle_test.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -46,7 +46,7 @@ func TestThrottleBacklog(t *testing.T) {
 			assertNoError(t, err)
 
 			assertEqual(t, http.StatusOK, res.StatusCode)
-			buf, err := ioutil.ReadAll(res.Body)
+			buf, err := io.ReadAll(res.Body)
 			assertNoError(t, err)
 			assertEqual(t, testContent, buf)
 		}(i)
@@ -131,7 +131,7 @@ func TestThrottleTriggerGatewayTimeout(t *testing.T) {
 			res, err := client.Get(server.URL)
 			assertNoError(t, err)
 
-			buf, err := ioutil.ReadAll(res.Body)
+			buf, err := io.ReadAll(res.Body)
 			assertNoError(t, err)
 			assertEqual(t, http.StatusTooManyRequests, res.StatusCode)
 			assertEqual(t, errTimedOut, strings.TrimSpace(string(buf)))
@@ -170,7 +170,7 @@ func TestThrottleMaximum(t *testing.T) {
 			assertNoError(t, err)
 			assertEqual(t, http.StatusOK, res.StatusCode)
 
-			buf, err := ioutil.ReadAll(res.Body)
+			buf, err := io.ReadAll(res.Body)
 			assertNoError(t, err)
 			assertEqual(t, testContent, buf)
 		}(i)
@@ -189,7 +189,7 @@ func TestThrottleMaximum(t *testing.T) {
 			res, err := client.Get(server.URL)
 			assertNoError(t, err)
 
-			buf, err := ioutil.ReadAll(res.Body)
+			buf, err := io.ReadAll(res.Body)
 			assertNoError(t, err)
 			assertEqual(t, http.StatusTooManyRequests, res.StatusCode)
 			assertEqual(t, errCapacityExceeded, strings.TrimSpace(string(buf)))


### PR DESCRIPTION
This package has been deprecated since Go 1.16, most of the uses were removed in #962, these are the remaining few.