### PR TITLE
feat(middleware): compress all text/* types by default

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -14,10 +14,7 @@ import (
 )
 
 var defaultCompressibleContentTypes = []string{
-	"text/html",
-	"text/css",
-	"text/plain",
-	"text/javascript",
+	"text/*",
 	"application/javascript",
 	"application/x-javascript",
 	"application/json",
@@ -78,7 +75,11 @@ func NewCompressor(level int, types ...string) *Compressor {
 		}
 	} else {
 		for _, t := range defaultCompressibleContentTypes {
-			allowedTypes[t] = struct{}{}
+			if before, ok := strings.CutSuffix(t, "/*"); ok {
+				allowedWildcards[before] = struct{}{}
+			} else {
+				allowedTypes[t] = struct{}{}
+			}
 		}
 	}
 

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -14,10 +14,7 @@ import (
 )
 
 var defaultCompressibleContentTypes = []string{
-	"text/html",
-	"text/css",
-	"text/plain",
-	"text/javascript",
+	"text/*",
 	"application/javascript",
 	"application/x-javascript",
 	"application/json",
@@ -80,7 +77,11 @@ func NewCompressor(level int, types ...string) *Compressor {
 		}
 	} else {
 		for _, t := range defaultCompressibleContentTypes {
-			allowedTypes[t] = struct{}{}
+			if before, ok := strings.CutSuffix(t, "/*"); ok {
+				allowedWildcards[before] = struct{}{}
+			} else {
+				allowedTypes[t] = struct{}{}
+			}
 		}
 	}
 

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -109,6 +109,26 @@ func TestCompressor(t *testing.T) {
 	}
 }
 
+func TestCompressorDefaultsTextMarkdown(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Compress(5))
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown")
+		w.Write([]byte("# Hello"))
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	resp, body := testRequestWithAcceptedEncodings(t, ts, "GET", "/", "gzip")
+	if body != "# Hello" {
+		t.Errorf("unexpected body: %q", body)
+	}
+	if got := resp.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Errorf("expected gzip encoding, got %q", got)
+	}
+}
+
 func TestCompressorWildcards(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -119,7 +139,8 @@ func TestCompressorWildcards(t *testing.T) {
 	}{
 		{
 			name:       "defaults",
-			typesCount: 10,
+			typesCount: 6,
+			wcCount:    1,
 		},
 		{
 			name:       "no wildcard",

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -109,6 +109,26 @@ func TestCompressor(t *testing.T) {
 	}
 }
 
+func TestCompressorDefaultsTextMarkdown(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(Compress(5))
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown")
+		w.Write([]byte("# Hello"))
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	resp, body := testRequestWithAcceptedEncodings(t, ts, "GET", "/", "gzip")
+	if body != "# Hello" {
+		t.Errorf("unexpected body: %q", body)
+	}
+	if got := resp.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Errorf("expected gzip encoding, got %q", got)
+	}
+}
+
 func TestCompressorWildcards(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -119,7 +139,8 @@ func TestCompressorWildcards(t *testing.T) {
 	}{
 		{
 			name:       "defaults",
-			typesCount: len(defaultCompressibleContentTypes),
+			typesCount: len(defaultCompressibleContentTypes) - 1,
+			wcCount:    1,
 		},
 		{
 			name:       "no wildcard",


### PR DESCRIPTION
- Replace explicit `text/html`, `text/css`, `text/plain`, `text/javascript` entries in `defaultCompressibleContentTypes` with a single `text/*` wildcard
- Fix `NewCompressor` to parse wildcard patterns in the defaults path, not only when types are explicitly passed
- Add test asserting `text/markdown` is gzip-compressed with default settings

I realise there have been a number of compression-related pull requests in the past, but hopefully this is small enough and has tests so is easy to merge in.