### PR TITLE
respect NoColor setting in defaultLogEntry.Panic()

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -160,7 +160,7 @@ func (l *defaultLogEntry) Write(status, bytes int, header http.Header, elapsed t
 }
 
 func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
-	PrintPrettyStack(v)
+	printPrettyStack(v, l.useColor)
 }
 
 func init() {

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -52,9 +52,13 @@ func Recoverer(next http.Handler) http.Handler {
 var recovererErrorWriter io.Writer = os.Stderr
 
 func PrintPrettyStack(rvr interface{}) {
+	printPrettyStack(rvr, true)
+}
+
+func printPrettyStack(rvr interface{}, useColor bool) {
 	debugStack := debug.Stack()
 	s := prettyStack{}
-	out, err := s.parse(debugStack, rvr)
+	out, err := s.parse(debugStack, rvr, useColor)
 	if err == nil {
 		recovererErrorWriter.Write(out)
 	} else {
@@ -66,9 +70,8 @@ func PrintPrettyStack(rvr interface{}) {
 type prettyStack struct {
 }
 
-func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
+func (s prettyStack) parse(debugStack []byte, rvr interface{}, useColor bool) ([]byte, error) {
 	var err error
-	useColor := true
 	buf := &bytes.Buffer{}
 
 	cW(buf, false, bRed, "\n")

--- a/middleware/recoverer_test.go
+++ b/middleware/recoverer_test.go
@@ -12,6 +12,10 @@ import (
 
 func panickingHandler(http.ResponseWriter, *http.Request) { panic("foo") }
 
+type testLogger struct{ t *testing.T }
+
+func (l testLogger) Print(v ...interface{}) {}
+
 func TestRecoverer(t *testing.T) {
 	r := chi.NewRouter()
 
@@ -39,6 +43,37 @@ func TestRecoverer(t *testing.T) {
 		}
 	}
 	t.Fatal("First func call line should start with ->.")
+}
+
+func TestRecovererNoColor(t *testing.T) {
+	oldIsTTY := IsTTY
+	IsTTY = true
+	defer func() { IsTTY = oldIsTTY }()
+
+	r := chi.NewRouter()
+
+	oldRecovererErrorWriter := recovererErrorWriter
+	defer func() { recovererErrorWriter = oldRecovererErrorWriter }()
+	buf := &bytes.Buffer{}
+	recovererErrorWriter = buf
+
+	r.Use(RequestLogger(&DefaultLogFormatter{Logger: testLogger{t}, NoColor: true}))
+	r.Use(Recoverer)
+	r.Get("/", panickingHandler)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	res, _ := testRequest(t, ts, "GET", "/", nil)
+	assertEqual(t, res.StatusCode, http.StatusInternalServerError)
+
+	output := buf.String()
+	if len(output) == 0 {
+		t.Fatal("expected panic output, got nothing")
+	}
+	if strings.Contains(output, "\033[") {
+		t.Fatal("expected no ANSI escape codes in panic output when NoColor is set")
+	}
 }
 
 func TestRecovererAbortHandler(t *testing.T) {


### PR DESCRIPTION
Fixes #1042.

`defaultLogEntry.Panic()` called `PrintPrettyStack()` which hardcodes `useColor = true`, ignoring the formatter's NoColor setting.