### PR TITLE
fix: detect and prevent self-mounting to avoid infinite loop

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -291,6 +291,12 @@ func (mx *Mux) Mount(pattern string, handler http.Handler) {
 		panic(fmt.Sprintf("chi: attempting to Mount() a nil handler on '%s'", pattern))
 	}
 
+	// Prevent self-mounting: mounting a router on itself (or its Group) causes
+	// infinite recursion because the handler routes back into the same tree.
+	if subr, ok := handler.(*Mux); ok && subr.tree == mx.tree {
+		panic("chi: Mount() handler shares the same routing tree; self-mounting causes infinite recursion")
+	}
+
 	// Provide runtime safety for ensuring a pattern isn't mounted on an existing
 	// routing pattern.
 	if mx.tree.findPattern(pattern+"*") || mx.tree.findPattern(pattern+"/*") {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1482,6 +1482,32 @@ func TestMountingExistingPath(t *testing.T) {
 	r.Mount("/hi", http.HandlerFunc(handler))
 }
 
+func TestMountSelfMountPanic(t *testing.T) {
+	t.Run("Group", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic for self-mount via Group")
+			} else if msg, ok := r.(string); !ok || msg != "chi: Mount() handler shares the same routing tree; self-mounting causes infinite recursion" {
+				t.Errorf("expected self-mount panic message, got: %v", r)
+			}
+		}()
+
+		r := NewRouter()
+		r.Mount("/", r.Group(func(r Router) {}))
+	})
+
+	t.Run("Direct", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic for direct self-mount")
+			}
+		}()
+
+		r := NewRouter()
+		r.Mount("/", r)
+	})
+}
+
 func TestMountingSimilarPattern(t *testing.T) {
 	r := NewRouter()
 	r.Get("/hi", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Add guard in `Mount()` to detect when a router is mounted on itself
- Prevents infinite recursion/stack overflow when `r.Mount("/", r.Group(...))`

## Root Cause
When a router is mounted on itself (directly or via `Group()`), requests cause infinite recursion because the router keeps dispatching to itself.

## Testing
- Added test verifying self-mount detection

Fixes #843

Made with [Cursor](https://cursor.com)