### PR TITLE
Add tests for panic behavior on malformed route patterns

### DIFF
--- a/panic_test.go
+++ b/panic_test.go
@@ -1,0 +1,61 @@
+package chi
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestPanicOnUnclosedBrace(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic()")
+		}
+	}()
+
+	r := NewRouter()
+	r.Get("/{open", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestPanicOnDuplicateParamKey(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic()")
+		}
+	}()
+
+	r := NewRouter()
+	r.Get("/{id}/things/{id}", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestPanicOnInvalidRegexp(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic()")
+		}
+	}()
+
+	r := NewRouter()
+	r.Get("/{id:[invalid}", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestPanicOnNilRouteHandler(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic()")
+		}
+	}()
+
+	r := NewRouter()
+	r.Route("/path", nil)
+}
+
+func TestPanicOnNilMountHandler(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic()")
+		}
+	}()
+
+	r := NewRouter()
+	r.Mount("/path", nil)
+}

--- a/panic_test.go
+++ b/panic_test.go
@@ -35,7 +35,7 @@ func TestPanicOnInvalidRegexp(t *testing.T) {
 	}()
 
 	r := NewRouter()
-	r.Get("/{id:[invalid}", func(w http.ResponseWriter, r *http.Request) {})
+	r.Get("/{id:(abc}", func(w http.ResponseWriter, r *http.Request) {})
 }
 
 func TestPanicOnNilRouteHandler(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds test coverage for five existing panic guard paths in route pattern
validation that were not explicitly covered by tests. No production code was changed.

Covered cases:
- Unclosed `{` brace in route pattern (`tree.go:patNextSegment`)
- Duplicate parameter keys in pattern (`tree.go:patParamKeys`) — addresses the TODO at `tree_test.go:194`
- Invalid regexp in route parameter (`tree.go:addChild`)
- `Route()` called with nil function (`mux.go:Route`)
- `Mount()` called with nil handler (`mux.go:Mount`)

## Test plan
- [x] All five new tests pass: `go test -v -run TestPanic ./...`
- [x] Full test suite passes: `go test ./...`
- [x] No production code modified