### PR TITLE
Fix httpFancyWriter.ReadFrom double-counting BytesWritten with Tee

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -208,8 +208,9 @@ func (f *http2FancyWriter) Push(target string, opts *http.PushOptions) error {
 
 func (f *httpFancyWriter) ReadFrom(r io.Reader) (int64, error) {
 	if f.basicWriter.tee != nil {
+		// io.Copy will call basicWriter.Write, which already
+		// increments basicWriter.bytes, so we must not add again.
 		n, err := io.Copy(&f.basicWriter, r)
-		f.basicWriter.bytes += int(n)
 		return n, err
 	}
 	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)

--- a/middleware/wrap_writer_test.go
+++ b/middleware/wrap_writer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -43,6 +44,30 @@ func TestBasicWritesTeesWritesWithoutDiscard(t *testing.T) {
 	assertEqual(t, []byte("hello world"), original.Body.Bytes())
 	assertEqual(t, []byte("hello world"), buf.Bytes())
 	assertEqual(t, 11, wrap.BytesWritten())
+}
+
+func TestHttpFancyWriterReadFromWithTee(t *testing.T) {
+	// When a tee is set, ReadFrom uses io.Copy through basicWriter.Write,
+	// which already increments the bytes counter. The ReadFrom method must
+	// not double-count the bytes.
+	original := &httptest.ResponseRecorder{
+		HeaderMap: make(http.Header),
+		Body:      new(bytes.Buffer),
+	}
+	f := &httpFancyWriter{basicWriter: basicWriter{ResponseWriter: original}}
+
+	var teeBuf bytes.Buffer
+	f.Tee(&teeBuf)
+
+	input := "hello world"
+	n, err := f.ReadFrom(strings.NewReader(input))
+	assertNoError(t, err)
+
+	assertEqual(t, int64(len(input)), n)
+	assertEqual(t, []byte(input), original.Body.Bytes())
+	assertEqual(t, []byte(input), teeBuf.Bytes())
+	// BytesWritten must equal the number of bytes written, not double.
+	assertEqual(t, len(input), f.BytesWritten())
 }
 
 func TestBasicWriterDiscardsWritesToOriginalResponseWriter(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix `httpFancyWriter.ReadFrom` double-counting bytes when a `Tee` writer is set
- `io.Copy(&f.basicWriter, r)` routes through `basicWriter.Write()` which already increments `bytes`; the additional `f.basicWriter.bytes += int(n)` after `io.Copy` caused `BytesWritten()` to return 2x the actual value
- Add regression test that verifies `BytesWritten()` accuracy after `ReadFrom` with `Tee`

Fixes #1067

## Test plan
- [x] New test `TestHttpFancyWriterReadFromWithTee` fails before fix, passes after
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)