### PR TITLE
Fix compress middleware Accept-Encoding parsing (substring + q=0)

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -254,7 +254,10 @@ func matchAcceptEncoding(accepted []string, encoding string) bool {
 		if params != "" {
 			params = strings.TrimSpace(params)
 			if qval, ok := strings.CutPrefix(params, "q="); ok {
-				if q, err := strconv.ParseFloat(strings.TrimSpace(qval), 32); err == nil && q == 0 {
+				// Strip any trailing parameters after the quality value.
+				qval, _, _ = strings.Cut(qval, ";")
+				qval = strings.TrimSpace(qval)
+				if q, err := strconv.ParseFloat(qval, 32); err == nil && q == 0 {
 					continue
 				}
 			}

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -239,9 +240,27 @@ func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, strin
 
 func matchAcceptEncoding(accepted []string, encoding string) bool {
 	for _, v := range accepted {
-		if strings.Contains(v, encoding) {
-			return true
+		// Extract the encoding name (before any ";q=" quality parameter)
+		// and trim surrounding whitespace.
+		name, params, _ := strings.Cut(v, ";")
+		name = strings.TrimSpace(name)
+
+		if name != encoding {
+			continue
 		}
+
+		// If a quality parameter is present and equals zero, the encoding
+		// is explicitly rejected (RFC 9110, Section 12.5.3).
+		if params != "" {
+			params = strings.TrimSpace(params)
+			if qval, ok := strings.CutPrefix(params, "q="); ok {
+				if q, err := strconv.ParseFloat(strings.TrimSpace(qval), 32); err == nil && q == 0 {
+					continue
+				}
+			}
+		}
+
+		return true
 	}
 	return false
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -109,6 +109,89 @@ func TestCompressor(t *testing.T) {
 	}
 }
 
+func TestMatchAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		accepted []string
+		encoding string
+		want     bool
+	}{
+		{
+			name:     "exact match",
+			accepted: []string{"gzip"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "match with whitespace",
+			accepted: []string{" gzip"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "match with quality value",
+			accepted: []string{"gzip;q=1.0"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "no match",
+			accepted: []string{"deflate"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "encoding excluded with q=0",
+			accepted: []string{"gzip;q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "should not substring match",
+			accepted: []string{"br"},
+			encoding: "b",
+			want:     false,
+		},
+		{
+			name:     "should not substring match prefix",
+			accepted: []string{"bgzip"},
+			encoding: "gzip",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchAcceptEncoding(tt.accepted, tt.encoding)
+			if got != tt.want {
+				t.Errorf("matchAcceptEncoding(%v, %q) = %v, want %v", tt.accepted, tt.encoding, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompressorRespectsQualityZero(t *testing.T) {
+	// When a client sends Accept-Encoding: gzip;q=0, the server must not
+	// compress the response with gzip (q=0 means "not acceptable").
+	r := chi.NewRouter()
+	compressor := NewCompressor(5, "text/html")
+	r.Use(compressor.Handler)
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte("hello"))
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	// gzip;q=0 means "I do NOT accept gzip"
+	resp, _ := testRequestWithAcceptedEncodings(t, ts, "GET", "/", "gzip;q=0, deflate")
+	if got := resp.Header.Get("Content-Encoding"); got == "gzip" {
+		t.Errorf("server used gzip despite q=0; Content-Encoding = %q", got)
+	}
+}
+
 func TestCompressorWildcards(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -158,6 +158,42 @@ func TestMatchAcceptEncoding(t *testing.T) {
 			encoding: "gzip",
 			want:     false,
 		},
+		{
+			name:     "q=0 in decimal form",
+			accepted: []string{"gzip;q=0.0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "q=0 max precision",
+			accepted: []string{"gzip;q=0.000"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "smallest non-zero quality",
+			accepted: []string{"gzip;q=0.001"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "whitespace around semicolon",
+			accepted: []string{"gzip ; q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "q=0 with trailing params",
+			accepted: []string{"gzip;q=0;ext=foo"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "explicit full quality",
+			accepted: []string{"gzip;q=1"},
+			encoding: "gzip",
+			want:     true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Fix `matchAcceptEncoding` to use exact encoding name comparison instead of `strings.Contains` substring matching
- Respect `q=0` quality values per RFC 9110 Section 12.5.3, which means "encoding not acceptable"
- Previously, `Accept-Encoding: gzip;q=0` would still compress with gzip, and `Accept-Encoding: br` could incorrectly match a hypothetical encoder named `b`

Fixes #1069

## Test plan
- [x] New `TestMatchAcceptEncoding` unit tests cover exact matching, whitespace handling, quality values, and substring rejection
- [x] New `TestCompressorRespectsQualityZero` integration test confirms end-to-end fix
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)