### PR TITLE
Fix httpFancyWriter.ReadFrom double-counting BytesWritten with Tee

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -208,9 +208,8 @@ func (f *http2FancyWriter) Push(target string, opts *http.PushOptions) error {
 
 func (f *httpFancyWriter) ReadFrom(r io.Reader) (int64, error) {
 	if f.basicWriter.tee != nil {
-		n, err := io.Copy(&f.basicWriter, r)
-		f.basicWriter.bytes += int(n)
-		return n, err
+		// io.Copy calls basicWriter.Write, which already increments bytes.
+		return io.Copy(&f.basicWriter, r)
 	}
 	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)
 	f.basicWriter.maybeWriteHeader()

--- a/middleware/wrap_writer_test.go
+++ b/middleware/wrap_writer_test.go
@@ -2,8 +2,10 @@ package middleware
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -43,6 +45,57 @@ func TestBasicWritesTeesWritesWithoutDiscard(t *testing.T) {
 	assertEqual(t, []byte("hello world"), original.Body.Bytes())
 	assertEqual(t, []byte("hello world"), buf.Bytes())
 	assertEqual(t, 11, wrap.BytesWritten())
+}
+
+func TestFancyWriterReadFromBytesCounting(t *testing.T) {
+	t.Run("With Tee", func(t *testing.T) {
+		original := &httptest.ResponseRecorder{
+			HeaderMap: make(http.Header),
+			Body:      new(bytes.Buffer),
+		}
+		f := &httpFancyWriter{basicWriter: basicWriter{ResponseWriter: original}}
+
+		var tee bytes.Buffer
+		f.Tee(&tee)
+
+		data := "hello world"
+		n, err := f.ReadFrom(strings.NewReader(data))
+		assertNoError(t, err)
+		assertEqual(t, int64(len(data)), n)
+
+		// BytesWritten must equal the actual data length, not double it.
+		assertEqual(t, len(data), f.BytesWritten())
+		assertEqual(t, []byte(data), original.Body.Bytes())
+		assertEqual(t, []byte(data), tee.Bytes())
+	})
+
+	t.Run("Without Tee", func(t *testing.T) {
+		recorder := &readerFromRecorder{
+			ResponseRecorder: httptest.ResponseRecorder{
+				HeaderMap: make(http.Header),
+				Body:      new(bytes.Buffer),
+			},
+		}
+		f := &httpFancyWriter{basicWriter: basicWriter{ResponseWriter: recorder}}
+
+		data := "hello world"
+		n, err := f.ReadFrom(strings.NewReader(data))
+		assertNoError(t, err)
+		assertEqual(t, int64(len(data)), n)
+
+		assertEqual(t, len(data), f.BytesWritten())
+		assertEqual(t, []byte(data), recorder.Body.Bytes())
+	})
+}
+
+// readerFromRecorder wraps httptest.ResponseRecorder and implements io.ReaderFrom.
+// This satisfies the type assertion in the non-tee path of httpFancyWriter.ReadFrom.
+type readerFromRecorder struct {
+	httptest.ResponseRecorder
+}
+
+func (r *readerFromRecorder) ReadFrom(src io.Reader) (int64, error) {
+	return io.Copy(r.Body, src)
 }
 
 func TestBasicWriterDiscardsWritesToOriginalResponseWriter(t *testing.T) {


### PR DESCRIPTION
## Summary

`httpFancyWriter.ReadFrom` double-counts `BytesWritten()` when a Tee writer is set.

When `tee != nil`, `ReadFrom` uses `io.Copy(&f.basicWriter, r)` which routes writes through `basicWriter.Write()`. `Write` already increments `basicWriter.bytes` on line 112. However, `ReadFrom` also adds `n` to `basicWriter.bytes` again on line 212, doubling the reported count.

The non-tee path is correct — `rf.ReadFrom` bypasses `basicWriter.Write`, so its manual increment is needed.

`http2FancyWriter` does not implement `ReadFrom`; HTTP/2 handles streaming at the framing layer.

## Fix

Remove the redundant `f.basicWriter.bytes += int(n)` on the tee path. `io.Copy` through `basicWriter.Write` handles byte counting.

## Test

Added `TestFancyWriterReadFromBytesCounting` with subtests for both the tee and non-tee paths, verifying `BytesWritten()` returns the correct count (not 2x).

Fixes #1067