### PR TITLE
Fix typo in Route doc comment

### DIFF
--- a/chi.go
+++ b/chi.go
@@ -77,7 +77,7 @@ type Router interface {
 	// path, with a fresh middleware stack for the inline-Router.
 	Group(fn func(r Router)) Router
 
-	// Route mounts a sub-Router along a `pattern`` string.
+	// Route mounts a sub-Router along a `pattern` string.
 	Route(pattern string, fn func(r Router)) Router
 
 	// Mount attaches another http.Handler along ./pattern/*


### PR DESCRIPTION
Follow-up to fe2c065: that commit fixed the typo in `README.md`, while the same extra backtick still exists in the source `Route` doc comment.