### PR TITLE
fix compress middleware: exact match and respect q=0 in Accept-Encoding

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -239,9 +239,25 @@ func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, strin
 
 func matchAcceptEncoding(accepted []string, encoding string) bool {
 	for _, v := range accepted {
-		if strings.Contains(v, encoding) {
-			return true
+		// Split on ";" to separate the encoding name from quality params (e.g. "gzip;q=0.5")
+		parts := strings.SplitN(strings.TrimSpace(v), ";", 2)
+		name := strings.TrimSpace(parts[0])
+
+		if name != encoding {
+			continue
 		}
+
+		// Per RFC 9110 §12.5.3, q=0 means the encoding is explicitly not acceptable
+		if len(parts) > 1 {
+			for _, param := range strings.Split(parts[1], ";") {
+				param = strings.TrimSpace(param)
+				if strings.EqualFold(param, "q=0") {
+					return false
+				}
+			}
+		}
+
+		return true
 	}
 	return false
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -215,3 +215,38 @@ func decodeResponseBody(t *testing.T, resp *http.Response) string {
 
 	return string(respBody)
 }
+
+func TestMatchAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		accepted []string
+		encoding string
+		want     bool
+	}{
+		// exact match
+		{[]string{"gzip"}, "gzip", true},
+		// q=0 means explicitly not acceptable
+		{[]string{"gzip;q=0"}, "gzip", false},
+		{[]string{"gzip; q=0"}, "gzip", false},
+		// q>0 is acceptable
+		{[]string{"gzip;q=0.5"}, "gzip", true},
+		{[]string{"gzip;q=1"}, "gzip", true},
+		// substring must not match (br != b)
+		{[]string{"br"}, "b", false},
+		// substring must not match (bgzip != gzip)
+		{[]string{"bgzip"}, "gzip", false},
+		// wildcard
+		{[]string{"*"}, "gzip", true},
+		// no match
+		{[]string{"deflate"}, "gzip", false},
+		// multiple encodings
+		{[]string{"deflate", "gzip"}, "gzip", true},
+		{[]string{"deflate", "gzip;q=0"}, "gzip", false},
+	}
+
+	for _, tc := range tests {
+		got := matchAcceptEncoding(tc.accepted, tc.encoding)
+		if got != tc.want {
+			t.Errorf("matchAcceptEncoding(%v, %q) = %v, want %v", tc.accepted, tc.encoding, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1069

`matchAcceptEncoding` used `strings.Contains` which caused two bugs:

1. **Substring false positives** — `Accept-Encoding: br` incorrectly matched encoding `b`, `bgzip` matched `gzip`
2. **q=0 ignored** — per [RFC 9110 §12.5.3](https://httpwg.org/specs/rfc9110.html#field.accept-encoding), `q=0` means the encoding is explicitly not acceptable, but `strings.Contains("gzip;q=0", "gzip")` returned true

**Fix:** parse the encoding token properly — split on `;`, trim whitespace, exact-match the name, reject when `q=0`.

Added unit tests covering all edge cases.