### PR TITLE
Fix double-counting of bytes in httpFancyWriter.ReadFrom with tee

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -209,7 +209,6 @@ func (f *http2FancyWriter) Push(target string, opts *http.PushOptions) error {
 func (f *httpFancyWriter) ReadFrom(r io.Reader) (int64, error) {
 	if f.basicWriter.tee != nil {
 		n, err := io.Copy(&f.basicWriter, r)
-		f.basicWriter.bytes += int(n)
 		return n, err
 	}
 	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)


### PR DESCRIPTION
## Problem

When a tee writer is set, `ReadFrom` uses `io.Copy(&f.basicWriter, r)` which routes data through `basicWriter.Write()`. That method already increments `b.bytes` (line 112). Then line 212 **also** increments `f.basicWriter.bytes += int(n)`, double-counting the same bytes.

## Solution

Remove the redundant `f.basicWriter.bytes += int(n)` line in the tee branch. `Write()` already handles the counting.

The non-tee branch (line 217-218) is correct as-is because `rf.ReadFrom()` calls the underlying `ResponseWriter` directly, bypassing `basicWriter.Write()`.

Fixes #1067