### PR TITLE
middleware: fix httpFancyWriter.ReadFrom double-counting bytes with Tee

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -208,8 +208,10 @@ func (f *http2FancyWriter) Push(target string, opts *http.PushOptions) error {
 
 func (f *httpFancyWriter) ReadFrom(r io.Reader) (int64, error) {
 	if f.basicWriter.tee != nil {
+		// Route through basicWriter.Write so that data is also written to the
+		// tee writer. basicWriter.Write already increments basicWriter.bytes,
+		// so we must NOT add n again here (that would double-count).
 		n, err := io.Copy(&f.basicWriter, r)
-		f.basicWriter.bytes += int(n)
 		return n, err
 	}
 	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)

--- a/middleware/wrap_writer_test.go
+++ b/middleware/wrap_writer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -83,4 +84,28 @@ func TestBasicWriterDiscardsWritesToOriginalResponseWriter(t *testing.T) {
 		assertEqual(t, 0, original.Body.Len())
 		assertEqual(t, 11, wrap.BytesWritten())
 	})
+}
+
+// TestHttpFancyWriterReadFromByteCountWithTee is a regression test for
+// https://github.com/go-chi/chi/issues/1067.
+// httpFancyWriter.ReadFrom was adding n to basicWriter.bytes even when the
+// write went through basicWriter.Write (which already increments the counter),
+// resulting in double-counting the bytes when a Tee writer was set.
+func TestHttpFancyWriterReadFromByteCountWithTee(t *testing.T) {
+	original := &httptest.ResponseRecorder{
+		HeaderMap: make(http.Header),
+		Body:      new(bytes.Buffer),
+	}
+	f := &httpFancyWriter{basicWriter: basicWriter{ResponseWriter: original}}
+
+	var teeBuf bytes.Buffer
+	f.Tee(&teeBuf)
+
+	const input = "hello world"
+	n, err := f.ReadFrom(strings.NewReader(input))
+	assertNoError(t, err)
+	assertEqual(t, int64(len(input)), n)
+	// Before the fix, BytesWritten() returned 22 (double-counted).
+	assertEqual(t, len(input), f.BytesWritten())
+	assertEqual(t, []byte(input), teeBuf.Bytes())
 }


### PR DESCRIPTION
## Summary

`httpFancyWriter.ReadFrom` in `middleware/wrap_writer.go` double-counted `BytesWritten()` when a Tee writer was set.

When `tee != nil`, the code called `io.Copy(&f.basicWriter, r)`, which routes every write through `basicWriter.Write`. `Write` already increments `basicWriter.bytes`. After the copy returned, the old code then did:

```go
f.basicWriter.bytes += int(n)   // BUG: already counted inside Write
```

…adding `n` a second time. The result: `BytesWritten()` returned exactly **twice** the actual number of bytes transferred.

## Fix

Remove the redundant `f.basicWriter.bytes += int(n)` line in the tee branch. The non-tee path (which delegates to the underlying `ReaderFrom`, bypassing `Write`) is not affected and still needs to add `n` itself.

## Test

Added `TestHttpFancyWriterReadFromByteCountWithTee` that reproduces the original bug (it fails before the fix and passes after). The full middleware test suite still passes.

Fixes #1067