### PR TITLE
Add trusted CIDR prefix tests for ClientIPFromXFFHeader

### DIFF
--- a/middleware/client_ip_test.go
+++ b/middleware/client_ip_test.go
@@ -114,6 +114,104 @@ func TestClientIPFromXFFHeader(t *testing.T) {
 	}
 }
 
+func TestClientIPFromXFFHeaderWithTrustedPrefixes(t *testing.T) {
+	tt := []struct {
+		name            string
+		trustedPrefixes []string
+		xff             []string
+		out             string
+	}{
+		// XFF: client → trusted proxy. Skips the trusted proxy and returns the client IP.
+		{
+			name:            "single_trusted_proxy",
+			trustedPrefixes: []string{"203.0.113.0/24"},
+			xff:             []string{"100.100.100.100, 203.0.113.1"},
+			out:             "100.100.100.100",
+		},
+		// XFF: client → trusted proxy1 → trusted proxy2. Both trusted hops are skipped.
+		{
+			name:            "multiple_trusted_proxies_chain",
+			trustedPrefixes: []string{"203.0.113.0/24", "198.51.100.0/24"},
+			xff:             []string{"100.100.100.100, 203.0.113.1, 198.51.100.5"},
+			out:             "100.100.100.100",
+		},
+		// XFF: fake_ip, real_client, trusted_proxy.
+		// An attacker prepending a forged IP is foiled because the right-to-left traversal
+		// skips the trusted proxy and stops at real_client, never reaching fake_ip.
+		{
+			name:            "spoofing_attempt_ignored",
+			trustedPrefixes: []string{"203.0.113.0/24"},
+			xff:             []string{"1.2.3.4, 100.100.100.100, 203.0.113.1"},
+			out:             "100.100.100.100",
+		},
+		// Every IP in XFF falls within the trusted range; no client IP can be determined.
+		{
+			name:            "all_trusted_returns_empty",
+			trustedPrefixes: []string{"203.0.113.0/24"},
+			xff:             []string{"203.0.113.2, 203.0.113.1"},
+			out:             "",
+		},
+		// The first address of a /24 (.0) is inside the trusted range and must be skipped.
+		{
+			name:            "trusted_prefix_boundary_first_addr",
+			trustedPrefixes: []string{"203.0.113.0/24"},
+			xff:             []string{"100.100.100.100, 203.0.113.0"},
+			out:             "100.100.100.100",
+		},
+		// The last address of a /24 (.255) is inside the trusted range and must be skipped.
+		{
+			name:            "trusted_prefix_boundary_last_addr",
+			trustedPrefixes: []string{"203.0.113.0/24"},
+			xff:             []string{"100.100.100.100, 203.0.113.255"},
+			out:             "100.100.100.100",
+		},
+		// An IP just outside the trusted prefix (203.0.114.x) is not trusted and is
+		// returned as the client IP.
+		{
+			name:            "ip_just_outside_trusted_prefix_is_client",
+			trustedPrefixes: []string{"203.0.113.0/24"},
+			xff:             []string{"203.0.114.1, 203.0.113.1"},
+			out:             "203.0.114.1",
+		},
+		// With no trusted prefixes configured, the rightmost public IP is returned as-is.
+		{
+			name:            "no_trusted_prefixes_rightmost_public",
+			trustedPrefixes: []string{},
+			xff:             []string{"100.100.100.100, 200.200.200.200"},
+			out:             "200.200.200.200",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			for _, v := range tc.xff {
+				req.Header.Add("X-Forwarded-For", v)
+			}
+
+			w := httptest.NewRecorder()
+
+			r := chi.NewRouter()
+			r.Use(ClientIPFromXFFHeader(tc.trustedPrefixes...))
+
+			var clientIP string
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				clientIP = GetClientIP(r.Context())
+				w.Write([]byte("Hello World"))
+			})
+			r.ServeHTTP(w, req)
+
+			if w.Code != 200 {
+				t.Errorf("Response Code should be 200")
+			}
+
+			if clientIP != tc.out {
+				t.Errorf("expected %v, got %v", tc.out, clientIP)
+			}
+		})
+	}
+}
+
 func TestClientIPFromRemoteAddr(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "192.0.2.1:1234" // Simulate the remote address set by http.Server.


### PR DESCRIPTION
Covers single/multiple trusted proxy chains, spoofing attempts, prefix boundary values, and no-prefix baseline as requested in PR #967.