### PR TITLE
Refresh contributor setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 ## Prerequisites
 
 1. [Install Go][go-install].
-2. Download the sources and switch the working directory:
+2. Clone the repository and switch the working directory:
 
     ```bash
-    go get -u -d github.com/go-chi/chi
-    cd $GOPATH/src/github.com/go-chi/chi
+    git clone https://github.com/go-chi/chi.git
+    cd chi
     ```
 
 ## Submitting a Pull Request
@@ -16,10 +16,10 @@ A typical workflow is:
 
 1. [Fork the repository.][fork]
 2. [Create a topic branch.][branch]
-3. Add tests for your change.
-4. Run `go test`. If your tests pass, return to the step 3.
-5. Implement the change and ensure the steps from the previous step pass.
-6. Run `goimports -w .`, to ensure the new code conforms to Go formatting guideline.
+3. Implement the change.
+4. Add tests for your change.
+5. Run `go test ./...`. If your tests fail, return to steps 3 and 4.
+6. Run `goimports -w .` to ensure the new code conforms to Go formatting guidelines.
 7. [Add, commit and push your changes.][git-help]
 8. [Submit a pull request.][pull-req]
 
@@ -28,4 +28,3 @@ A typical workflow is:
 [branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches 
 [git-help]: https://docs.github.com/en
 [pull-req]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
-

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and [docgen](https://github.com/go-chi/docgen). We hope you enjoy it too!
 ## Install
 
 ```sh
-go get -u github.com/go-chi/chi/v5
+go get github.com/go-chi/chi/v5
 ```
 
 


### PR DESCRIPTION

**Repo:** go-chi/chi (⭐ 18000)
**Type:** docs
**Files changed:** 2
**Lines:** +8/-9

## What
This change updates the contributor onboarding docs to match current Go module workflows. `CONTRIBUTING.md` now tells contributors to clone the repository directly instead of using the old `go get` plus `$GOPATH` flow, fixes the pull request checklist so implementation happens before test authoring, and corrects the retry instruction to loop back only when tests fail. `README.md` is also aligned by removing the unnecessary `-u` flag from the install command.

## Why
The previous instructions mixed pre-module Go workspace guidance with an incorrect test loop that told contributors to go back when tests passed. That creates friction for new contributors and can send them down the wrong path before they even make a change. Tightening these docs makes local setup clearer and keeps the contribution workflow accurate.

## Testing
Verified the markdown diff locally and checked that the updated commands and workflow text are internally consistent. No automated checks were run because this is a docs-only change.

## Risk
Low - this only adjusts documentation and does not affect runtime behavior.
