### PR TITLE
fix(middleware): skip CleanPath for HTTP CONNECT requests

### DIFF
--- a/middleware/clean_path.go
+++ b/middleware/clean_path.go
@@ -11,6 +11,11 @@ import (
 // For example, if a user requests /users//1 or //users////1 will both be treated as: /users/1
 func CleanPath(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		rctx := chi.RouteContext(r.Context())
 
 		routePath := rctx.RoutePath


### PR DESCRIPTION
Closes #807

## Summary

CleanPath middleware calls `path.Clean()` on the request path, but HTTP CONNECT requests use authority-form targets (`host:port`), not path-form URIs. `path.Clean()` corrupts these targets (e.g., `example.com:8080` → `example.com:8080` with altered RoutePath), causing route mismatches and 404 responses.

## Fix

Skip CleanPath logic entirely for CONNECT method, passing the request through unchanged. This preserves the authority-form target per RFC 9110 Section 9.3.4.

## Test Plan

- All existing tests pass (`go test ./...`)
- Reproduce with the example from #807: CONNECT request to `host:port` through a router using CleanPath middleware
- Before: 404 Not Found
- After: correctly routed to CONNECT handler