### PR TITLE
middleware: stop double-counting BytesWritten in httpFancyWriter.ReadFrom

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -208,9 +208,9 @@ func (f *http2FancyWriter) Push(target string, opts *http.PushOptions) error {
 
 func (f *httpFancyWriter) ReadFrom(r io.Reader) (int64, error) {
 	if f.basicWriter.tee != nil {
-		n, err := io.Copy(&f.basicWriter, r)
-		f.basicWriter.bytes += int(n)
-		return n, err
+		// io.Copy routes through basicWriter.Write, which already
+		// updates bytes. Adding n here would double-count.
+		return io.Copy(&f.basicWriter, r)
 	}
 	rf := f.basicWriter.ResponseWriter.(io.ReaderFrom)
 	f.basicWriter.maybeWriteHeader()

--- a/middleware/wrap_writer_test.go
+++ b/middleware/wrap_writer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -83,4 +84,26 @@ func TestBasicWriterDiscardsWritesToOriginalResponseWriter(t *testing.T) {
 		assertEqual(t, 0, original.Body.Len())
 		assertEqual(t, 11, wrap.BytesWritten())
 	})
+}
+
+// httpFancyWriter.ReadFrom used to double-count BytesWritten when a Tee
+// was set: io.Copy goes through basicWriter.Write which already adds to
+// bytes, and ReadFrom added n on top.
+func TestHttpFancyWriterReadFromWithTeeCountsBytesOnce(t *testing.T) {
+	original := &httptest.ResponseRecorder{
+		HeaderMap: make(http.Header),
+		Body:      new(bytes.Buffer),
+	}
+	f := &httpFancyWriter{basicWriter: basicWriter{ResponseWriter: original}}
+
+	var teeBuf bytes.Buffer
+	f.Tee(&teeBuf)
+
+	n, err := f.ReadFrom(strings.NewReader("hello world"))
+	assertNoError(t, err)
+
+	assertEqual(t, int64(11), n)
+	assertEqual(t, 11, f.BytesWritten())
+	assertEqual(t, []byte("hello world"), original.Body.Bytes())
+	assertEqual(t, []byte("hello world"), teeBuf.Bytes())
 }


### PR DESCRIPTION
Fixes #1067.

`httpFancyWriter.ReadFrom`'s tee branch ran `io.Copy(&f.basicWriter, r)` and then added `n` to `f.basicWriter.bytes`. But the copy goes through `basicWriter.Write`, which already does `b.bytes += n` at the end. So `BytesWritten()` returned twice the real number of bytes whenever a `Tee` writer was set.

The non-tee branch is unaffected — it uses `ResponseWriter.(io.ReaderFrom).ReadFrom` directly, which doesn't go through `basicWriter.Write`, so it still needs the explicit `+= n`.

Added a regression test exercising the tee path.