### PR TITLE
middleware: thread useColor through Panic so NoColor logger emits plain text

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -160,7 +160,7 @@ func (l *defaultLogEntry) Write(status, bytes int, header http.Header, elapsed t
 }
 
 func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
-	PrintPrettyStack(v)
+	printPrettyStackWithColor(v, l.useColor)
 }
 
 func init() {

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -52,8 +52,16 @@ func Recoverer(next http.Handler) http.Handler {
 var recovererErrorWriter io.Writer = os.Stderr
 
 func PrintPrettyStack(rvr interface{}) {
+	printPrettyStackWithColor(rvr, true)
+}
+
+// printPrettyStackWithColor is the same as PrintPrettyStack but lets
+// callers (the request logger, primarily) thread through whether the
+// destination supports ANSI color so the panic output respects the
+// surrounding NoColor configuration.
+func printPrettyStackWithColor(rvr interface{}, useColor bool) {
 	debugStack := debug.Stack()
-	s := prettyStack{}
+	s := prettyStack{useColor: useColor}
 	out, err := s.parse(debugStack, rvr)
 	if err == nil {
 		recovererErrorWriter.Write(out)
@@ -64,11 +72,12 @@ func PrintPrettyStack(rvr interface{}) {
 }
 
 type prettyStack struct {
+	useColor bool
 }
 
 func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
 	var err error
-	useColor := true
+	useColor := s.useColor
 	buf := &bytes.Buffer{}
 
 	cW(buf, false, bRed, "\n")

--- a/middleware/recoverer_test.go
+++ b/middleware/recoverer_test.go
@@ -65,3 +65,42 @@ func TestRecovererAbortHandler(t *testing.T) {
 
 	r.ServeHTTP(w, req)
 }
+
+// Regression for #1042. When the logger has NoColor=true, the pretty
+// stack output from a panic should also be uncolored. Previously
+// defaultLogEntry.Panic forwarded to PrintPrettyStack which hard-coded
+// useColor=true, so panic traces always came out with ANSI sequences
+// when the surrounding terminal was a TTY, even if the request logs
+// above them honored NoColor.
+func TestRequestLoggerPanicRespectsNoColor(t *testing.T) {
+	// cW gates color emission on the package-level IsTTY flag, which is
+	// false in CI. Flip it on for this test so the buggy path actually
+	// produces ANSI sequences for the regression to catch.
+	oldIsTTY := IsTTY
+	IsTTY = true
+	defer func() { IsTTY = oldIsTTY }()
+
+	oldWriter := recovererErrorWriter
+	defer func() { recovererErrorWriter = oldWriter }()
+	buf := &bytes.Buffer{}
+	recovererErrorWriter = buf
+
+	r := chi.NewRouter()
+	r.Use(RequestLogger(&DefaultLogFormatter{Logger: nopLogger{}, NoColor: true}))
+	r.Use(Recoverer)
+	r.Get("/", panickingHandler)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	res, _ := testRequest(t, ts, "GET", "/", nil)
+	assertEqual(t, res.StatusCode, http.StatusInternalServerError)
+
+	if strings.Contains(buf.String(), "\x1b[") {
+		t.Fatalf("panic output should be uncolored when NoColor=true, got:\n%s", buf.String())
+	}
+}
+
+type nopLogger struct{}
+
+func (nopLogger) Print(...interface{}) {}


### PR DESCRIPTION
Fixes #1042.

\`defaultLogEntry.Panic\` forwarded straight to \`PrintPrettyStack\`, which hard-coded \`useColor=true\`. When the surrounding terminal was a TTY, panic stack traces always came out with ANSI sequences even if the request logs above them honored \`NoColor=true\`. That's especially noisy on a non-color sink (Docker logs, file capture) where the rest of the request logger output is plain.

Added an internal \`printPrettyStackWithColor(rvr, useColor)\` helper. The exported \`PrintPrettyStack\` keeps its default colored behavior (the standalone \`Recoverer\` path doesn't have a logger to inherit a NoColor setting from). \`defaultLogEntry.Panic\` calls the helper with its existing \`useColor\` field, so panic output now matches the rest of the request log.

Added \`TestRequestLoggerPanicRespectsNoColor\` which flips the package-level \`IsTTY\` flag on for the duration of the test (otherwise \`cW\` would skip color emission entirely and the regression wouldn't trigger in CI).