### PR TITLE
mux: dedupe the Allow header on 405 responses

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -517,7 +517,17 @@ func (mx *Mux) updateRouteHandler() {
 // methods for the route.
 func methodNotAllowedHandler(methodsAllowed ...methodTyp) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Multiple overlapping routes (wildcards plus a literal that
+		// matches the same path, for example) can each contribute the
+		// same method to methodsAllowed, so dedupe before writing the
+		// Allow header. Without this a 405 ended up with e.g.
+		// `Allow: POST, POST, POST`. See #996.
+		seen := make(map[methodTyp]struct{}, len(methodsAllowed))
 		for _, m := range methodsAllowed {
+			if _, ok := seen[m]; ok {
+				continue
+			}
+			seen[m] = struct{}{}
 			w.Header().Add("Allow", reverseMethodMap[m])
 		}
 		w.WriteHeader(405)

--- a/mux_test.go
+++ b/mux_test.go
@@ -428,6 +428,28 @@ func TestMethodNotAllowed(t *testing.T) {
 	})
 }
 
+// Regression for #996. When multiple wildcard routes overlap with a
+// concrete one and the request method isn't registered on any of
+// them, the Allow header used to repeat the same method once per
+// matching route ("Allow: POST, POST, POST").
+func TestMethodNotAllowed_DedupesAllowHeader(t *testing.T) {
+	r := NewRouter()
+	r.Post("/article/1-2-3", func(w http.ResponseWriter, _ *http.Request) {})
+	r.Post("/article/{a}", func(w http.ResponseWriter, _ *http.Request) {})
+	r.Post("/article/{b}-{c}", func(w http.ResponseWriter, _ *http.Request) {})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	resp, _ := testRequest(t, ts, "GET", "/article/1-2-3", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+	if got := resp.Header.Values("Allow"); len(got) != 1 || got[0] != "POST" {
+		t.Fatalf("Allow header = %v, want [POST]", got)
+	}
+}
+
 func TestMuxNestedMethodNotAllowed(t *testing.T) {
 	r := NewRouter()
 	r.Get("/root", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #996.

\`methodsAllowed\` gets appended to once per matching tree branch, so when multiple overlapping wildcard routes (or a literal and a wildcard that match the same path) only differ by their pattern but share the same method, the resulting Allow header repeated that method per branch. The reporter's three-route setup produced \`Allow: POST, POST, POST\`.

Dedupe in \`methodNotAllowedHandler\` so each method shows up at most once. No change to the routing logic itself.

Added \`TestMethodNotAllowed_DedupesAllowHeader\` covering the regression.