### PR TITLE
fix: set Request.Pattern from RoutePattern()

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -472,7 +472,7 @@ func (mx *Mux) routeHTTP(w http.ResponseWriter, r *http.Request) {
 			value := rctx.URLParams.Values[i]
 			r.SetPathValue(key, value)
 		}
-		r.Pattern = rctx.routePattern
+		r.Pattern = rctx.RoutePattern()
 
 		h.ServeHTTP(w, r)
 		return

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -34,15 +34,29 @@ func TestPattern(t *testing.T) {
 			method:      "POST",
 			requestPath: "/users/Gojo/friends/all-of-them/and/more",
 		},
+		{
+			name:        "Nested sub-router",
+			pattern:     "/accounts/{accountID}/hi",
+			method:      "GET",
+			requestPath: "/accounts/44/hi",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := NewRouter()
 
-			r.Handle(tc.method+" "+tc.pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte(r.Pattern))
-			}))
+			if tc.name == "Nested sub-router" {
+				r.Route("/accounts/{accountID}", func(r Router) {
+					r.Handle(tc.method+" /hi", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Write([]byte(r.Pattern))
+					}))
+				})
+			} else {
+				r.Handle(tc.method+" "+tc.pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Write([]byte(r.Pattern))
+				}))
+			}
 
 			ts := httptest.NewServer(r)
 			defer ts.Close()


### PR DESCRIPTION
## Summary

On Go 1.23+, `http.Request.Pattern` is now populated with the full composed route pattern from `RouteContext.RoutePattern()` instead of the per-sub-router `routePattern` field.

## Tests

- Extended `TestPattern` with a nested sub-router case (`/accounts/{accountID}/hi`).

Fixes #1089