### PR TITLE
Preserve request precondition headers in NoCache

### DIFF
--- a/middleware/nocache.go
+++ b/middleware/nocache.go
@@ -19,15 +19,6 @@ var noCacheHeaders = map[string]string{
 	"X-Accel-Expires": "0",
 }
 
-var etagHeaders = []string{
-	"ETag",
-	"If-Modified-Since",
-	"If-Match",
-	"If-None-Match",
-	"If-Range",
-	"If-Unmodified-Since",
-}
-
 // NoCache is a simple piece of middleware that sets a number of HTTP headers to prevent
 // a router (or subrouter) from being cached by an upstream proxy and/or client.
 //
@@ -39,14 +30,6 @@ var etagHeaders = []string{
 //	Pragma: no-cache (for HTTP/1.0 proxies/clients)
 func NoCache(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-
-		// Delete any ETag headers that may have been set
-		for _, v := range etagHeaders {
-			if r.Header.Get(v) != "" {
-				r.Header.Del(v)
-			}
-		}
-
 		// Set our NoCache headers
 		for k, v := range noCacheHeaders {
 			w.Header().Set(k, v)

--- a/middleware/nocache_test.go
+++ b/middleware/nocache_test.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNoCachePreservesRequestPreconditionHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("If-Match", `"current"`)
+	req.Header.Set("If-None-Match", `"stale"`)
+	req.Header.Set("If-Unmodified-Since", "Wed, 21 Oct 2015 07:28:00 GMT")
+
+	handler := NoCache(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("If-Match"); got != `"current"` {
+			t.Fatalf("If-Match header = %q, want %q", got, `"current"`)
+		}
+		if got := r.Header.Get("If-None-Match"); got != `"stale"` {
+			t.Fatalf("If-None-Match header = %q, want %q", got, `"stale"`)
+		}
+		if got := r.Header.Get("If-Unmodified-Since"); got != "Wed, 21 Oct 2015 07:28:00 GMT" {
+			t.Fatalf("If-Unmodified-Since header = %q", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Cache-Control"); got == "" {
+		t.Fatal("Cache-Control header was not set")
+	}
+	if got := rec.Code; got != http.StatusNoContent {
+		t.Fatalf("status code = %d, want %d", got, http.StatusNoContent)
+	}
+}


### PR DESCRIPTION
## Summary
- stop NoCache from deleting conditional request headers such as If-Match and If-None-Match
- add a regression test that confirms precondition headers reach downstream handlers while no-cache response headers are still set

Fixes #801.

## Tests
- GOMODCACHE=/tmp/chi-801-gomodcache GOCACHE=/tmp/chi-801-gocache go test ./middleware -run TestNoCachePreservesRequestPreconditionHeaders -count=1
- GOMODCACHE=/tmp/chi-801-gomodcache GOCACHE=/tmp/chi-801-gocache go test ./middleware -run 'NoCache|TestNoCachePreservesRequestPreconditionHeaders' -count=1
- GOMODCACHE=/tmp/chi-801-gomodcache GOCACHE=/tmp/chi-801-gocache go test ./middleware -count=1
- GOMODCACHE=/tmp/chi-801-gomodcache GOCACHE=/tmp/chi-801-gocache go test ./... -count=1
- git diff --check