### PR TITLE
fix(middleware): match Accept-Encoding exactly and honor q=0

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -239,9 +239,35 @@ func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, strin
 
 func matchAcceptEncoding(accepted []string, encoding string) bool {
 	for _, v := range accepted {
-		if strings.Contains(v, encoding) {
+		parts := strings.SplitN(strings.TrimSpace(v), ";", 2)
+		name := strings.TrimSpace(parts[0])
+
+		if name == "*" {
+			if len(parts) > 1 {
+				for _, param := range strings.Split(parts[1], ";") {
+					param = strings.TrimSpace(param)
+					if strings.EqualFold(param, "q=0") {
+						return false
+					}
+				}
+			}
 			return true
 		}
+
+		if name != encoding {
+			continue
+		}
+
+		if len(parts) > 1 {
+			for _, param := range strings.Split(parts[1], ";") {
+				param = strings.TrimSpace(param)
+				if strings.EqualFold(param, "q=0") {
+					return false
+				}
+			}
+		}
+
+		return true
 	}
 	return false
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -215,3 +215,30 @@ func decodeResponseBody(t *testing.T, resp *http.Response) string {
 
 	return string(respBody)
 }
+
+func TestMatchAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		accepted []string
+		encoding string
+		want     bool
+	}{
+		{[]string{"gzip"}, "gzip", true},
+		{[]string{"gzip;q=0"}, "gzip", false},
+		{[]string{"gzip; q=0"}, "gzip", false},
+		{[]string{"gzip;q=0.5"}, "gzip", true},
+		{[]string{"gzip;q=1"}, "gzip", true},
+		{[]string{"br"}, "b", false},
+		{[]string{"bgzip"}, "gzip", false},
+		{[]string{"*"}, "gzip", true},
+		{[]string{"deflate"}, "gzip", false},
+		{[]string{"deflate", "gzip"}, "gzip", true},
+		{[]string{"deflate", "gzip;q=0"}, "gzip", false},
+	}
+
+	for _, tc := range tests {
+		got := matchAcceptEncoding(tc.accepted, tc.encoding)
+		if got != tc.want {
+			t.Errorf("matchAcceptEncoding(%v, %q) = %v, want %v", tc.accepted, tc.encoding, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `matchAcceptEncoding` to use exact token matching instead of substring matching
- Reject encodings explicitly disabled with `q=0` per RFC 9110
- Preserve wildcard acceptance for `Accept-Encoding: *`

## Problem
The compress middleware used `strings.Contains`, which caused false positives such as:
- `Accept-Encoding: br` matching encoding `b`
- `Accept-Encoding: bgzip` matching encoding `gzip`
- `Accept-Encoding: gzip;q=0` still selecting gzip

## Test plan
- [x] Added `TestMatchAcceptEncoding`
- [x] `go test ./middleware/... -run 'TestMatchAcceptEncoding|TestCompressor'`

Fixes #1069