### PR TITLE
fix: consistently decode URL path parameters

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package chi
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -100,7 +101,12 @@ func (x *Context) Reset() {
 func (x *Context) URLParam(key string) string {
 	for k := len(x.URLParams.Keys) - 1; k >= 0; k-- {
 		if x.URLParams.Keys[k] == key {
-			return x.URLParams.Values[k]
+			value := x.URLParams.Values[k]
+			decoded, err := url.PathUnescape(value)
+			if err != nil {
+				return value
+			}
+			return decoded
 		}
 	}
 	return ""

--- a/middleware/clean_path.go
+++ b/middleware/clean_path.go
@@ -15,10 +15,9 @@ func CleanPath(next http.Handler) http.Handler {
 
 		routePath := rctx.RoutePath
 		if routePath == "" {
-			if r.URL.RawPath != "" {
-				routePath = r.URL.RawPath
-			} else {
-				routePath = r.URL.Path
+			routePath = r.URL.EscapedPath()
+			if routePath == "" {
+				routePath = "/"
 			}
 			rctx.RoutePath = path.Clean(routePath)
 		}

--- a/middleware/get_head.go
+++ b/middleware/get_head.go
@@ -13,10 +13,9 @@ func GetHead(next http.Handler) http.Handler {
 			rctx := chi.RouteContext(r.Context())
 			routePath := rctx.RoutePath
 			if routePath == "" {
-				if r.URL.RawPath != "" {
-					routePath = r.URL.RawPath
-				} else {
-					routePath = r.URL.Path
+				routePath = r.URL.EscapedPath()
+				if routePath == "" {
+					routePath = "/"
 				}
 			}
 

--- a/mux.go
+++ b/mux.go
@@ -445,11 +445,7 @@ func (mx *Mux) routeHTTP(w http.ResponseWriter, r *http.Request) {
 	// The request routing path
 	routePath := rctx.RoutePath
 	if routePath == "" {
-		if r.URL.RawPath != "" {
-			routePath = r.URL.RawPath
-		} else {
-			routePath = r.URL.Path
-		}
+		routePath = r.URL.EscapedPath()
 		if routePath == "" {
 			routePath = "/"
 		}

--- a/mux_test.go
+++ b/mux_test.go
@@ -1728,7 +1728,7 @@ func TestEscapedURLParams(t *testing.T) {
 			return
 		}
 		identifier := URLParam(r, "identifier")
-		if identifier != "http:%2f%2fexample.com%2fimage.png" {
+		if identifier != "http://example.com/image.png" {
 			t.Errorf("identifier path parameter incorrect %s", identifier)
 			return
 		}
@@ -1755,6 +1755,32 @@ func TestEscapedURLParams(t *testing.T) {
 
 	if _, body := testRequest(t, ts, "GET", "/api/http:%2f%2fexample.com%2fimage.png/full/max/0/color.png", nil); body != "success" {
 		t.Fatal(body)
+	}
+}
+
+func TestURLParamPathUnescape(t *testing.T) {
+	m := NewRouter()
+	m.Get("/{key}", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(URLParam(r, "key")))
+	})
+
+	ts := httptest.NewServer(m)
+	defer ts.Close()
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/It's%20great", "It's great"},
+		{"/It%20is%20great", "It is great"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if _, body := testRequest(t, ts, "GET", tt.path, nil); body != tt.want {
+				t.Fatalf("URLParam(%q) = %q, want %q", tt.path, body, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Use `r.URL.EscapedPath()` for route matching instead of preferring `RawPath` over `Path`
- Decode URL path parameters via `url.PathUnescape` in `Context.URLParam` so callers always receive decoded values
- Add regression test covering the inconsistent `%20` encoding cases from #832

## Test plan

- [x] `go test ./...`
- [x] `TestURLParamPathUnescape` — `/It's%20great` and `/It%20is%20great` both return `It is great` / `It's great`
- [x] `TestEscapedURLParams` — encoded slashes in identifier decode to `http://example.com/image.png`

Fixes #832