### PR TITLE
fix: detect self-mounting to prevent infinite recursion

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -291,6 +291,12 @@ func (mx *Mux) Mount(pattern string, handler http.Handler) {
 		panic(fmt.Sprintf("chi: attempting to Mount() a nil handler on '%s'", pattern))
 	}
 
+	// Prevent self-mounting: mounting a router on itself (or its Group) causes
+	// infinite recursion because the handler routes back into the same tree.
+	if subr, ok := handler.(*Mux); ok && subr.tree == mx.tree {
+		panic("chi: Mount() handler shares the same routing tree; self-mounting causes infinite recursion")
+	}
+
 	// Provide runtime safety for ensuring a pattern isn't mounted on an existing
 	// routing pattern.
 	if mx.tree.findPattern(pattern+"*") || mx.tree.findPattern(pattern+"/*") {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1482,6 +1482,32 @@ func TestMountingExistingPath(t *testing.T) {
 	r.Mount("/hi", http.HandlerFunc(handler))
 }
 
+func TestMountSelfMountPanic(t *testing.T) {
+	t.Run("Group", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic for self-mount via Group")
+			} else if msg, ok := r.(string); !ok || msg != "chi: Mount() handler shares the same routing tree; self-mounting causes infinite recursion" {
+				t.Errorf("expected self-mount panic message, got: %v", r)
+			}
+		}()
+
+		r := NewRouter()
+		r.Mount("/", r.Group(func(r Router) {}))
+	})
+
+	t.Run("Direct", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic for direct self-mount")
+			}
+		}()
+
+		r := NewRouter()
+		r.Mount("/", r)
+	})
+}
+
 func TestMountingSimilarPattern(t *testing.T) {
 	r := NewRouter()
 	r.Get("/hi", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Detect when `Mount()` receives a handler that shares the same routing tree as the parent mux
- Panic at registration time with a clear message instead of stack overflow at request time
- Covers both `r.Mount("/", r)` and `r.Mount("/", r.Group(...))` (Group shares the parent tree via `With()`)

Fixes #843

## Problem

`Group()` returns an inline mux that reuses the parent `tree` pointer. Mounting it at `/` on the same router causes `routeHTTP` to dispatch back into the same tree indefinitely, producing stack overflow or hung responses for unmatched paths.

## Test plan

- [x] `go test -run TestMountSelfMountPanic -v`
- [x] `go test -run TestMount -count=1`