### PR TITLE
feat: add StrictRouting to prefer static 405 over param fallback

### DIFF
--- a/context.go
+++ b/context.go
@@ -76,6 +76,7 @@ type Context struct {
 
 	methodsAllowed   []methodTyp // allowed methods in case of a 405
 	methodNotAllowed bool
+	strictRouting    bool
 }
 
 // Reset a routing context to its initial state.
@@ -92,6 +93,7 @@ func (x *Context) Reset() {
 	x.routeParams.Values = x.routeParams.Values[:0]
 	x.methodNotAllowed = false
 	x.methodsAllowed = x.methodsAllowed[:0]
+	x.strictRouting = false
 	x.parentCtx = nil
 }
 

--- a/mux.go
+++ b/mux.go
@@ -39,6 +39,12 @@ type Mux struct {
 	// Custom route not found handler
 	notFoundHandler http.HandlerFunc
 
+	// StrictRouting, when true, stops route matching after a static path matches
+	// but the requested HTTP method is not registered. Without this, chi may fall
+	// through to a parameterized route (e.g. /users/{id}) that accepts the method,
+	// treating a reserved static segment (e.g. /users/me) as a parameter value.
+	StrictRouting bool
+
 	// The middleware stack
 	middlewares []func(http.Handler) http.Handler
 
@@ -251,6 +257,7 @@ func (mx *Mux) With(middlewares ...func(http.Handler) http.Handler) Router {
 	im := &Mux{
 		pool: mx.pool, inline: true, parent: mx, tree: mx.tree, middlewares: mws,
 		notFoundHandler: mx.notFoundHandler, methodNotAllowedHandler: mx.methodNotAllowedHandler,
+		StrictRouting: mx.StrictRouting,
 	}
 
 	return im
@@ -441,6 +448,7 @@ func (mx *Mux) handle(method methodTyp, pattern string, handler http.Handler) *n
 func (mx *Mux) routeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Grab the route context object
 	rctx := r.Context().Value(RouteCtxKey).(*Context)
+	rctx.strictRouting = mx.StrictRouting
 
 	// The request routing path
 	routePath := rctx.RoutePath

--- a/mux_test.go
+++ b/mux_test.go
@@ -428,6 +428,53 @@ func TestMethodNotAllowed(t *testing.T) {
 	})
 }
 
+func TestStrictRoutingStaticMethodNotAllowed(t *testing.T) {
+	const updateBody = "updated"
+
+	newRouter := func(strict bool) *Mux {
+		r := NewRouter()
+		r.StrictRouting = strict
+		r.Get("/users/me", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("me"))
+		})
+		r.Put("/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(updateBody))
+		})
+		return r
+	}
+
+	t.Run("Default", func(t *testing.T) {
+		ts := httptest.NewServer(newRouter(false))
+		defer ts.Close()
+
+		if resp, body := testRequest(t, ts, "PUT", "/users/me", nil); resp.StatusCode != 200 || body != updateBody {
+			t.Fatalf("expected param route fallback, got %d %q", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("StrictRouting", func(t *testing.T) {
+		ts := httptest.NewServer(newRouter(true))
+		defer ts.Close()
+
+		resp, body := testRequest(t, ts, "PUT", "/users/me", nil)
+		if resp.StatusCode != 405 || body != "" {
+			t.Fatalf("expected 405 for static path with unsupported method, got %d %q", resp.StatusCode, body)
+		}
+		allowed := resp.Header.Values("Allow")
+		if len(allowed) != 1 || allowed[0] != "GET" {
+			t.Fatalf("expected Allow: GET, got %v", allowed)
+		}
+
+		if resp, body := testRequest(t, ts, "GET", "/users/me", nil); resp.StatusCode != 200 || body != "me" {
+			t.Fatalf("expected GET /users/me to succeed, got %d %q", resp.StatusCode, body)
+		}
+
+		if resp, body := testRequest(t, ts, "PUT", "/users/123", nil); resp.StatusCode != 200 || body != updateBody {
+			t.Fatalf("expected param route to still match numeric id, got %d %q", resp.StatusCode, body)
+		}
+	})
+}
+
 func TestMuxNestedMethodNotAllowed(t *testing.T) {
 	r := NewRouter()
 	r.Get("/root", func(w http.ResponseWriter, r *http.Request) {

--- a/tree.go
+++ b/tree.go
@@ -425,6 +425,10 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 			xsearch = xsearch[len(xn.prefix):]
 
 		case ntParam, ntRegexp:
+			if rctx.strictRouting && rctx.methodNotAllowed {
+				continue
+			}
+
 			// short-circuit and return no matching route for empty param values
 			if xsearch == "" {
 				continue


### PR DESCRIPTION
## Summary

- Adds opt-in `Mux.StrictRouting` (default `false` to preserve existing behavior)
- When enabled, stops route matching at parameterized/regexp nodes if a static path already matched but the requested HTTP method is not registered
- Returns `405 Method Not Allowed` instead of routing to a param handler that would treat a reserved static segment (e.g. `/users/me`) as a parameter value

Fixes #1035

## Problem

Given:

```go
r.Get("/users/me", handleCurrentUser)
r.Put("/users/{id}", updateUser)
```

`PUT /users/me` currently matches `PUT /users/{id}` with `id=me` instead of returning 405, which can bypass authorization or other logic tied to the static path.

## Approach

This follows the opt-in `StrictRouting` design discussed on the issue to avoid breaking callers who rely on the current param fallback behavior.

## Test plan

- [x] `go test -run TestStrictRoutingStaticMethodNotAllowed -v`
- [x] `go test ./... -count=1`