### PR TITLE
fix(middleware): parse Accept-Encoding values exactly

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -239,9 +240,22 @@ func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, strin
 
 func matchAcceptEncoding(accepted []string, encoding string) bool {
 	for _, v := range accepted {
-		if strings.Contains(v, encoding) {
-			return true
+		parts := strings.Split(v, ";")
+		if !strings.EqualFold(strings.TrimSpace(parts[0]), encoding) {
+			continue
 		}
+
+		for _, part := range parts[1:] {
+			key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+			if !ok || !strings.EqualFold(strings.TrimSpace(key), "q") {
+				continue
+			}
+			quality, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+			if err == nil && quality <= 0 {
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -169,6 +169,54 @@ func TestCompressorWildcards(t *testing.T) {
 	}
 }
 
+func TestMatchAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		accepted []string
+		encoding string
+		want     bool
+	}{
+		{
+			name:     "matches exact encoding",
+			accepted: []string{"gzip"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "matches exact encoding with quality",
+			accepted: []string{"gzip;q=0.5"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "rejects exact encoding with zero quality",
+			accepted: []string{"gzip;q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "rejects substring prefix match",
+			accepted: []string{"br"},
+			encoding: "b",
+			want:     false,
+		},
+		{
+			name:     "rejects substring suffix match",
+			accepted: []string{"bgzip"},
+			encoding: "gzip",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchAcceptEncoding(tt.accepted, tt.encoding); got != tt.want {
+				t.Fatalf("matchAcceptEncoding(%v, %q) = %v, want %v", tt.accepted, tt.encoding, got, tt.want)
+			}
+		})
+	}
+}
+
 func testRequestWithAcceptedEncodings(t *testing.T, ts *httptest.Server, method, path string, encodings ...string) (*http.Response, string) {
 	req, err := http.NewRequest(method, ts.URL+path, nil)
 	if err != nil {


### PR DESCRIPTION
Closes #1069

## Summary
- Match `Accept-Encoding` tokens exactly instead of using substring matching.
- Treat an exact encoding with `q=0` as not acceptable.
- Add regression coverage for exact matches, quality values, and substring false positives.

## Testing
- `go test ./middleware -run TestMatchAcceptEncoding -count=1`
- `go test ./middleware`
- `go test ./...`
- `HTTPS_PROXY=http://127.0.0.1:7897 HTTP_PROXY=http://127.0.0.1:7897 ALL_PROXY=http://127.0.0.1:7897 go run golang.org/x/tools/cmd/goimports@latest -w middleware/compress.go middleware/compress_test.go`
- `make test`