### PR TITLE
Honor Discard() in httpFancyWriter.ReadFrom

### DIFF
--- a/middleware/wrap_writer.go
+++ b/middleware/wrap_writer.go
@@ -207,10 +207,12 @@ func (f *http2FancyWriter) Push(target string, opts *http.PushOptions) error {
 }
 
 func (f *httpFancyWriter) ReadFrom(r io.Reader) (int64, error) {
-	if f.basicWriter.tee != nil {
-		// Route through basicWriter.Write so that data is also written to the
-		// tee writer. basicWriter.Write already increments basicWriter.bytes,
-		// so we must NOT add n again here (that would double-count).
+	if f.basicWriter.tee != nil || f.basicWriter.discard {
+		// Route through basicWriter.Write so that the tee and discard semantics
+		// are honored (the fast ReaderFrom path below would bypass both, writing
+		// straight to the original ResponseWriter). basicWriter.Write already
+		// increments basicWriter.bytes, so we must NOT add n again here (that
+		// would double-count).
 		n, err := io.Copy(&f.basicWriter, r)
 		return n, err
 	}

--- a/middleware/wrap_writer_test.go
+++ b/middleware/wrap_writer_test.go
@@ -2,11 +2,25 @@ package middleware
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+// readerFromRecorder is a ResponseRecorder that also satisfies io.ReaderFrom,
+// mirroring the real net/http response writer (which implements ReadFrom and
+// is what httpFancyWriter.ReadFrom fast-paths to). Bytes copied via ReadFrom
+// are recorded to the body so a test can observe whether they reached the
+// original writer.
+type readerFromRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (r *readerFromRecorder) ReadFrom(src io.Reader) (int64, error) {
+	return io.Copy(r.ResponseRecorder.Body, src)
+}
 
 func TestHttpFancyWriterRemembersWroteHeaderWhenFlushed(t *testing.T) {
 	f := &httpFancyWriter{basicWriter: basicWriter{ResponseWriter: httptest.NewRecorder()}}
@@ -108,4 +122,26 @@ func TestHttpFancyWriterReadFromByteCountWithTee(t *testing.T) {
 	// Before the fix, BytesWritten() returned 22 (double-counted).
 	assertEqual(t, len(input), f.BytesWritten())
 	assertEqual(t, []byte(input), teeBuf.Bytes())
+}
+
+// TestHttpFancyWriterReadFromHonorsDiscard verifies that Discard() suppresses
+// the body even when it is written via ReadFrom/io.Copy. Before the fix, the
+// non-tee ReadFrom path streamed straight to the original ResponseWriter's
+// ReaderFrom, bypassing the discard flag entirely.
+func TestHttpFancyWriterReadFromHonorsDiscard(t *testing.T) {
+	original := &readerFromRecorder{&httptest.ResponseRecorder{
+		HeaderMap: make(http.Header),
+		Body:      new(bytes.Buffer),
+	}}
+	f := &httpFancyWriter{basicWriter: basicWriter{ResponseWriter: original}}
+	f.Discard()
+
+	const input = "hello world"
+	n, err := f.ReadFrom(strings.NewReader(input))
+	assertNoError(t, err)
+	assertEqual(t, int64(len(input)), n)
+	// The data must NOT reach the original writer once Discard() is set.
+	assertEqual(t, 0, original.Body.Len())
+	// BytesWritten still reflects the bytes consumed.
+	assertEqual(t, len(input), f.BytesWritten())
 }


### PR DESCRIPTION
`httpFancyWriter.ReadFrom` only routes through `basicWriter.Write` when a tee writer is set. When it isn't, it streams straight to the original `ResponseWriter`'s `io.ReaderFrom` — bypassing the `discard` flag entirely.

So after a caller invokes `Discard()` (to suppress the proxied output and write the response itself later), any body sent via `ReadFrom`/`io.Copy` — e.g. `http.ServeContent`, `io.Copy(w, file)`, `http.ServeFile` — **still reaches the client**, defeating the purpose of `Discard()`. The plain `Write` path already respects discard; only the `ReadFrom` fast path missed it.

### Fix

Extend the slow-path condition to also cover discard, so `basicWriter.Write` (which honors both tee and discard) handles those cases. This mirrors the existing tee handling in the same function:

```go
if f.basicWriter.tee != nil || f.basicWriter.discard {
    n, err := io.Copy(&f.basicWriter, r)
    return n, err
}
```

The fast `rf.ReadFrom` path is now taken only for pure pass-through (no tee, no discard), where it's safe.

### Test

Added `TestHttpFancyWriterReadFromHonorsDiscard`, which writes via `ReadFrom` after `Discard()` and asserts the original writer received nothing while `BytesWritten()` still reflects the consumed bytes. It fails on `master` (original receives all 11 bytes) and passes with the fix. Full `go test ./middleware/` passes; `gofmt`/`go vet` clean.