### PR TITLE
Tidy build directives

### DIFF
--- a/middleware/profiler.go
+++ b/middleware/profiler.go
@@ -1,5 +1,4 @@
 //go:build !tinygo
-// +build !tinygo
 
 package middleware
 

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -1,6 +1,3 @@
-//go:build go1.23
-// +build go1.23
-
 package chi
 
 import (


### PR DESCRIPTION
Remove the obsolete "// +build" form which hasn't been needed since Go 1.18, and remove the Go 1.23 build directives as that matches our minimum version now.