### PR TITLE
fix(middleware): fix Accept-Encoding matching in compress middleware

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -239,9 +240,21 @@ func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, strin
 
 func matchAcceptEncoding(accepted []string, encoding string) bool {
 	for _, v := range accepted {
-		if strings.Contains(v, encoding) {
-			return true
+		name, params, _ := strings.Cut(strings.TrimSpace(v), ";")
+		if strings.TrimSpace(name) != encoding {
+			continue
 		}
+		for _, param := range strings.Split(params, ";") {
+			key, value, ok := strings.Cut(strings.TrimSpace(param), "=")
+			if !ok || strings.TrimSpace(key) != "q" {
+				continue
+			}
+			quality, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+			if err == nil && quality <= 0 {
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -241,12 +241,12 @@ func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, strin
 func matchAcceptEncoding(accepted []string, encoding string) bool {
 	for _, v := range accepted {
 		name, params, _ := strings.Cut(strings.TrimSpace(v), ";")
-		if strings.TrimSpace(name) != encoding {
+		if !strings.EqualFold(strings.TrimSpace(name), encoding) {
 			continue
 		}
 		for _, param := range strings.Split(params, ";") {
 			key, value, ok := strings.Cut(strings.TrimSpace(param), "=")
-			if !ok || strings.TrimSpace(key) != "q" {
+			if !ok || !strings.EqualFold(strings.TrimSpace(key), "q") {
 				continue
 			}
 			quality, err := strconv.ParseFloat(strings.TrimSpace(value), 64)

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -219,6 +219,12 @@ func TestMatchAcceptEncoding(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "mixed case encoding",
+			accepted: []string{"GZip"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
 			name:     "br should not match b",
 			accepted: []string{"br"},
 			encoding: "b",
@@ -245,6 +251,12 @@ func TestMatchAcceptEncoding(t *testing.T) {
 		{
 			name:     "q=0 with space",
 			accepted: []string{"gzip; q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "mixed case q=0 rejected",
+			accepted: []string{"gzip; Q=0"},
 			encoding: "gzip",
 			want:     false,
 		},

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -92,6 +92,18 @@ func TestCompressor(t *testing.T) {
 			acceptedEncodings: []string{"nop, gzip, deflate"},
 			expectedEncoding:  "nop",
 		},
+		{
+			name:              "gzip rejected with q=0 returns no encoding",
+			path:              "/gethtml",
+			acceptedEncodings: []string{"gzip;q=0"},
+			expectedEncoding:  "",
+		},
+		{
+			name:              "gzip rejected with q=0 falls back to deflate",
+			path:              "/gethtml",
+			acceptedEncodings: []string{"gzip;q=0", "deflate"},
+			expectedEncoding:  "deflate",
+		},
 	}
 
 	for _, tc := range tests {
@@ -164,6 +176,110 @@ func TestCompressorWildcards(t *testing.T) {
 			}
 			if len(compressor.allowedWildcards) != tt.wcCount {
 				t.Errorf("expected %d allowedWildcards, got %d", tt.wcCount, len(compressor.allowedWildcards))
+			}
+		})
+	}
+}
+
+func TestMatchAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		accepted []string
+		encoding string
+		want     bool
+	}{
+		{
+			name:     "exact match",
+			accepted: []string{"gzip"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "no match",
+			accepted: []string{"deflate"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "empty list",
+			accepted: []string{""},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "leading space",
+			accepted: []string{" gzip"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "trailing space",
+			accepted: []string{"gzip "},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "br should not match b",
+			accepted: []string{"br"},
+			encoding: "b",
+			want:     false,
+		},
+		{
+			name:     "gzip should not match zip",
+			accepted: []string{"gzip"},
+			encoding: "zip",
+			want:     false,
+		},
+		{
+			name:     "q=0 rejected",
+			accepted: []string{"gzip;q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "q=0.0 rejected",
+			accepted: []string{"gzip;q=0.0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "q=0 with space",
+			accepted: []string{"gzip; q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "q=0.5 accepted",
+			accepted: []string{"gzip;q=0.5"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "q=1.0 accepted",
+			accepted: []string{"gzip;q=1.0"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "match on second element",
+			accepted: []string{"deflate", "gzip"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "q=0 on second element",
+			accepted: []string{"deflate", "gzip;q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchAcceptEncoding(tt.accepted, tt.encoding)
+			if got != tt.want {
+				t.Errorf("matchAcceptEncoding(%v, %q) = %v, want %v",
+					tt.accepted, tt.encoding, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1069

## Summary

`matchAcceptEncoding` used substring matching, so values like `bgzip` could match `gzip`, and encodings explicitly rejected with `q=0` were still selected.

## Fix

Parse each `Accept-Encoding` item as an encoding token plus parameters, compare the token and `q` parameter name case-insensitively, and reject matches with a parsed quality value of `0` or lower.

This intentionally keeps the existing server-side encoder precedence and does not add wildcard or q-priority negotiation.

## Tests

Added helper-level regression coverage for exact matching, substring false positives, whitespace, mixed-case tokens and parameters, `q=0` / `q=0.0`, and multiple accepted encodings.

Added middleware-level cases for `gzip;q=0` returning no encoding and falling back to `deflate` when available.