### PR TITLE
fix(middleware): honor all-types compress wildcard

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -281,6 +281,9 @@ func (cw *compressResponseWriter) isCompressible() bool {
 		return true
 	}
 	if contentType, _, hadSlash := strings.Cut(contentType, "/"); hadSlash {
+		if _, ok := cw.contentWildcards[""]; ok {
+			return true
+		}
 		_, ok := cw.contentWildcards[contentType]
 		return ok
 	}

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -169,6 +169,53 @@ func TestCompressorWildcards(t *testing.T) {
 	}
 }
 
+func TestCompressorWildcardAllTypes(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(NewCompressor(5, "/*").Handler)
+
+	r.Get("/json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	})
+
+	r.Get("/html", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte("<p>ok</p>"))
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "application type matches all wildcard",
+			path: "/json",
+			body: `{"ok":true}`,
+		},
+		{
+			name: "text type matches all wildcard",
+			path: "/html",
+			body: "<p>ok</p>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body := testRequestWithAcceptedEncodings(t, ts, http.MethodGet, tt.path, "gzip")
+			if got := resp.Header.Get("Content-Encoding"); got != "gzip" {
+				t.Fatalf("expected gzip encoding, got %q", got)
+			}
+			if body != tt.body {
+				t.Fatalf("expected body %q, got %q", tt.body, body)
+			}
+		})
+	}
+}
+
 func testRequestWithAcceptedEncodings(t *testing.T, ts *httptest.Server, method, path string, encodings ...string) (*http.Response, string) {
 	req, err := http.NewRequest(method, ts.URL+path, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- make `NewCompressor(..., "/*")` behave as an actual all-types wildcard
- keep the existing wildcard parsing model and fix only the matching side
- add regression coverage for both `application/*` and `text/*` responses

## Problem
`NewCompressor(5, "/*")` is currently accepted as a valid wildcard pattern, but it silently does not work.

During setup, the pattern is normalized into an empty wildcard key via `strings.CutSuffix("/*", "/*")`, which is fine as an internal sentinel. The problem is in `isCompressible()`: wildcard matching only checks the top-level media type prefix (for example `text` or `application`) and never treats the empty key as a match-all sentinel.

That means the following configuration looks valid but compresses nothing:

```go
middleware.NewCompressor(5, "/*")
```

## Changes
- treat an empty wildcard key as "match any top-level media type" during content-type checks
- add a focused regression test showing that `"/*"` now compresses both `application/json` and `text/html; charset=utf-8`

The patch is intentionally narrow: it does not change the wildcard syntax rules, only makes the already-accepted `"/*"` form behave consistently.

Closes #868
