### PR TITLE
fix: deduplicate Allow header in 405 Method Not Allowed responses

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -517,7 +517,12 @@ func (mx *Mux) updateRouteHandler() {
 // methods for the route.
 func methodNotAllowedHandler(methodsAllowed ...methodTyp) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		seen := make(map[string]bool)
 		for _, m := range methodsAllowed {
+			if seen[reverseMethodMap[m]] {
+				continue
+			}
+			seen[reverseMethodMap[m]] = true
 			w.Header().Add("Allow", reverseMethodMap[m])
 		}
 		w.WriteHeader(405)

--- a/mux_test_405_test.go
+++ b/mux_test_405_test.go
@@ -1,0 +1,48 @@
+package chi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMethodNotAllowedDeduplication(t *testing.T) {
+	r := NewRouter()
+	r.Post("/article/1-2-3", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Post("/article/{a}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Post("/article/{b}-{c}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Post("/article/{b}-{c}-{d}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/article/1-2-3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 405 {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+
+	allow := resp.Header["Allow"]
+	// Count POST occurrences
+	count := 0
+	for _, v := range allow {
+		if v == "POST" {
+			count++
+		}
+	}
+	if count > 1 {
+		t.Errorf("Allow header has duplicate POST: %v (count=%d)", allow, count)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #996

When multiple routes with the same HTTP method but different patterns are registered (e.g., `/article/{a}`, `/article/{b}-{c}`, `/article/{b}-{c}-{d}`), the `Allow` header in 405 responses contains duplicate method entries like:

```
Allow: POST, POST, POST, POST
```

## Changes

- Added deduplication in `methodNotAllowedHandler` using a `seen` map to track methods already added to the Allow header
- Added test case to verify deduplication

## Before

```
Allow: POST, POST, POST, POST
```

## After

```
Allow: POST
```