### PR TITLE
fix(middleware): Logger.Panic respects NoColor in DefaultLogFormatter

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -166,7 +166,7 @@ func (l *defaultLogEntry) Write(status, bytes int, header http.Header, elapsed t
 }
 
 func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
-	PrintPrettyStack(v)
+	PrintPrettyStack(v, !l.NoColor)
 }
 
 func init() {

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -51,10 +51,14 @@ func Recoverer(next http.Handler) http.Handler {
 // for ability to test the PrintPrettyStack function
 var recovererErrorWriter io.Writer = os.Stderr
 
-func PrintPrettyStack(rvr interface{}) {
+func PrintPrettyStack(rvr interface{}, useColor ...bool) {
 	debugStack := debug.Stack()
 	s := prettyStack{}
-	out, err := s.parse(debugStack, rvr)
+	uc := true
+	if len(useColor) > 0 {
+		uc = useColor[0]
+	}
+	out, err := s.parse(debugStack, rvr, uc)
 	if err == nil {
 		recovererErrorWriter.Write(out)
 	} else {
@@ -66,9 +70,8 @@ func PrintPrettyStack(rvr interface{}) {
 type prettyStack struct {
 }
 
-func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
+func (s prettyStack) parse(debugStack []byte, rvr interface{}, useColor bool) ([]byte, error) {
 	var err error
-	useColor := true
 	buf := &bytes.Buffer{}
 
 	cW(buf, false, bRed, "\n")


### PR DESCRIPTION
## Summary

Fixes #1042

`defaultLogEntry.Panic()` was calling `PrintPrettyStack(v)` without passing the `NoColor` preference from `DefaultLogFormatter`, so panic output always used color regardless of the `NoColor` setting.

## Changes

- Adds optional `useColor ...bool` parameter to `PrintPrettyStack` (backward compatible, defaults to `true`)
- Wires `!l.NoColor` from `defaultLogEntry.Panic()` through to `PrintPrettyStack`
- The recoverer fallback path (no logEntry) still defaults to color, preserving existing behavior

## Before

Panic stack traces ignored the `NoColor: true` setting on `DefaultLogFormatter` and always used ANSI colors.

## After

When `DefaultLogFormatter{NoColor: true}` is used, panic stack traces are also printed without ANSI color codes.