### PR TITLE
feat(middleware): add text/xml and application/xml to default compressible types

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -23,6 +23,8 @@ var defaultCompressibleContentTypes = []string{
 	"application/json",
 	"application/atom+xml",
 	"application/rss+xml",
+	"application/xml",
+	"text/xml",
 	"image/svg+xml",
 }
 


### PR DESCRIPTION
## Summary

Fixes #920

XML content compresses very effectively (typically 70-90% reduction) and is commonly served by web applications, APIs, and RSS/Atom feeds. This adds `text/xml` and `application/xml` to the default compressible content types list.

Note that `application/atom+xml` and `application/rss+xml` were already in the list — but generic XML was not.

## Changes

- Added `application/xml` and `text/xml` to `defaultCompressibleContentTypes`