### PR TITLE
feat(mux): support http QUERY method ietf rfc10008

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ type Router interface {
 	Patch(pattern string, h http.HandlerFunc)
 	Post(pattern string, h http.HandlerFunc)
 	Put(pattern string, h http.HandlerFunc)
+	Query(pattern string, h http.HandlerFunc)
 	Trace(pattern string, h http.HandlerFunc)
 
 	// NotFound defines a handler to respond whenever a route could

--- a/chi.go
+++ b/chi.go
@@ -102,6 +102,7 @@ type Router interface {
 	Patch(pattern string, h http.HandlerFunc)
 	Post(pattern string, h http.HandlerFunc)
 	Put(pattern string, h http.HandlerFunc)
+	Query(pattern string, h http.HandlerFunc)
 	Trace(pattern string, h http.HandlerFunc)
 
 	// NotFound defines a handler to respond whenever a route could

--- a/mux.go
+++ b/mux.go
@@ -186,6 +186,12 @@ func (mx *Mux) Put(pattern string, handlerFn http.HandlerFunc) {
 	mx.handle(mPUT, pattern, handlerFn)
 }
 
+// Query adds the route `pattern` that matches a QUERY http method to
+// execute the `handlerFn` http.HandlerFunc.
+func (mx *Mux) Query(pattern string, handlerFn http.HandlerFunc) {
+	mx.handle(mQUERY, pattern, handlerFn)
+}
+
 // Trace adds the route `pattern` that matches a TRACE http method to
 // execute the `handlerFn` http.HandlerFunc.
 func (mx *Mux) Trace(pattern string, handlerFn http.HandlerFunc) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -1804,6 +1804,57 @@ func TestCustomHTTPMethod(t *testing.T) {
 	}
 }
 
+func TestQueryHTTPMethod(t *testing.T) {
+	r := NewRouter()
+
+	r.Get("/search", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("get"))
+	})
+
+	// QUERY is a safe, idempotent http method that conveys a request body,
+	// see RFC 10008.
+	r.Query("/search", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Write([]byte(fmt.Sprintf("query: %s", body)))
+	})
+
+	r.MethodFunc(MethodQuery, "/reports", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("reports"))
+	})
+
+	r.HandleFunc("/any", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("any"))
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	if _, body := testRequest(t, ts, MethodQuery, "/search", bytes.NewReader([]byte("select 1"))); body != "query: select 1" {
+		t.Fatal(body)
+	}
+	if _, body := testRequest(t, ts, "GET", "/search", nil); body != "get" {
+		t.Fatal(body)
+	}
+	if _, body := testRequest(t, ts, MethodQuery, "/reports", nil); body != "reports" {
+		t.Fatal(body)
+	}
+	if _, body := testRequest(t, ts, MethodQuery, "/any", nil); body != "any" {
+		t.Fatal(body)
+	}
+
+	// An unregistered method on the same route responds 405 with QUERY
+	// listed in the Allow header.
+	resp, _ := testRequest(t, ts, "POST", "/search", nil)
+	if resp.StatusCode != 405 {
+		t.Fatal(resp.Status)
+	}
+	allowedMethods := resp.Header.Values("Allow")
+	if len(allowedMethods) != 2 || ((allowedMethods[0] != "GET" || allowedMethods[1] != "QUERY") &&
+		(allowedMethods[1] != "GET" || allowedMethods[0] != "QUERY")) {
+		t.Fatal("Allow header should contain 2 headers: GET, QUERY. Received: ", allowedMethods)
+	}
+}
+
 func TestMuxMatch(t *testing.T) {
 	r := NewRouter()
 	r.Get("/hi", func(w http.ResponseWriter, r *http.Request) {

--- a/tree.go
+++ b/tree.go
@@ -26,11 +26,17 @@ const (
 	mPATCH
 	mPOST
 	mPUT
+	mQUERY
 	mTRACE
 )
 
 var mALL = mCONNECT | mDELETE | mGET | mHEAD |
-	mOPTIONS | mPATCH | mPOST | mPUT | mTRACE
+	mOPTIONS | mPATCH | mPOST | mPUT | mQUERY | mTRACE
+
+// MethodQuery is the HTTP QUERY method (RFC 10008), a safe, idempotent
+// method that conveys a request body. It is defined here until net/http
+// provides an equivalent constant.
+const MethodQuery = "QUERY"
 
 var methodMap = map[string]methodTyp{
 	http.MethodConnect: mCONNECT,
@@ -41,6 +47,7 @@ var methodMap = map[string]methodTyp{
 	http.MethodPatch:   mPATCH,
 	http.MethodPost:    mPOST,
 	http.MethodPut:     mPUT,
+	MethodQuery:        mQUERY,
 	http.MethodTrace:   mTRACE,
 }
 
@@ -53,6 +60,7 @@ var reverseMethodMap = map[methodTyp]string{
 	mPATCH:   http.MethodPatch,
 	mPOST:    http.MethodPost,
 	mPUT:     http.MethodPut,
+	mQUERY:   MethodQuery,
 	mTRACE:   http.MethodTrace,
 }
 


### PR DESCRIPTION
Adds support for [IETF RFC 10008](https://datatracker.ietf.org/doc/rfc10008/) - The HTTP QUERY Method

As support is not yet enabled in native GoLang net/http, we have introduced a temporary method definition directly into the project [here](https://github.com/go-chi/chi/compare/master...pjol:chi:master?expand=1#diff-050830ac4334170e8d335e1b95519052a3461c5b57a4ca38a0531e35a8f3d388R39). Once enabled in net/http, a clean 1-1 swap with our temporary method should be simple.