### PR TITLE
middleware/logger: respect NoColor in Panic output

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -166,7 +166,7 @@ func (l *defaultLogEntry) Write(status, bytes int, header http.Header, elapsed t
 }
 
 func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
-	PrintPrettyStack(v)
+	PrintPrettyStackWithColor(v, l.useColor)
 }
 
 func init() {

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -52,9 +52,14 @@ func Recoverer(next http.Handler) http.Handler {
 var recovererErrorWriter io.Writer = os.Stderr
 
 func PrintPrettyStack(rvr interface{}) {
+	PrintPrettyStackWithColor(rvr, true)
+}
+
+// PrintPrettyStackWithColor prints a pretty stack trace with color control.
+func PrintPrettyStackWithColor(rvr interface{}, useColor bool) {
 	debugStack := debug.Stack()
 	s := prettyStack{}
-	out, err := s.parse(debugStack, rvr)
+	out, err := s.parse(debugStack, rvr, useColor)
 	if err == nil {
 		recovererErrorWriter.Write(out)
 	} else {
@@ -66,9 +71,8 @@ func PrintPrettyStack(rvr interface{}) {
 type prettyStack struct {
 }
 
-func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
+func (s prettyStack) parse(debugStack []byte, rvr interface{}, useColor bool) ([]byte, error) {
 	var err error
-	useColor := true
 	buf := &bytes.Buffer{}
 
 	cW(buf, false, bRed, "\n")


### PR DESCRIPTION
Fixes #1042

defaultLogEntry.Panic() called PrintPrettyStack() which hardcoded useColor := true, ignoring the NoColor field on DefaultLogFormatter.

Added PrintPrettyStackWithColor(rvr, useColor) to accept a color flag, updated defaultLogEntry.Panic() to pass l.useColor, and kept PrintPrettyStack as a wrapper that defaults to 	rue for backward compatibility.