### PR TITLE
middleware: document printPrettyStack and harden NoColor panic test

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -166,7 +166,7 @@ func (l *defaultLogEntry) Write(status, bytes int, header http.Header, elapsed t
 }
 
 func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
-	PrintPrettyStackColor(v, l.useColor)
+	printPrettyStack(v, l.useColor)
 }
 
 func init() {

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -166,7 +166,7 @@ func (l *defaultLogEntry) Write(status, bytes int, header http.Header, elapsed t
 }
 
 func (l *defaultLogEntry) Panic(v interface{}, stack []byte) {
-	PrintPrettyStack(v)
+	PrintPrettyStackColor(v, l.useColor)
 }
 
 func init() {

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -51,16 +51,14 @@ func Recoverer(next http.Handler) http.Handler {
 // for ability to test the PrintPrettyStack function
 var recovererErrorWriter io.Writer = os.Stderr
 
-// PrintPrettyStack prints a formatted, coloured stack trace to stderr.
 func PrintPrettyStack(rvr interface{}) {
-	PrintPrettyStackColor(rvr, true)
+	printPrettyStack(rvr, true)
 }
 
-// PrintPrettyStackColor prints a formatted stack trace to stderr.
-// When useColor is false ANSI colour codes are suppressed, which is useful
-// for terminals that do not support them (e.g. on Windows) or when output is
-// being captured.
-func PrintPrettyStackColor(rvr interface{}, useColor bool) {
+// printPrettyStack prints a formatted stack trace to stderr. When useColor is
+// false, ANSI colour codes are suppressed, which is useful for terminals that
+// do not support them (e.g. on Windows) or when output is being captured.
+func printPrettyStack(rvr interface{}, useColor bool) {
 	debugStack := debug.Stack()
 	s := prettyStack{}
 	out, err := s.parse(debugStack, rvr, useColor)

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -51,10 +51,19 @@ func Recoverer(next http.Handler) http.Handler {
 // for ability to test the PrintPrettyStack function
 var recovererErrorWriter io.Writer = os.Stderr
 
+// PrintPrettyStack prints a formatted, coloured stack trace to stderr.
 func PrintPrettyStack(rvr interface{}) {
+	PrintPrettyStackColor(rvr, true)
+}
+
+// PrintPrettyStackColor prints a formatted stack trace to stderr.
+// When useColor is false ANSI colour codes are suppressed, which is useful
+// for terminals that do not support them (e.g. on Windows) or when output is
+// being captured.
+func PrintPrettyStackColor(rvr interface{}, useColor bool) {
 	debugStack := debug.Stack()
 	s := prettyStack{}
-	out, err := s.parse(debugStack, rvr)
+	out, err := s.parse(debugStack, rvr, useColor)
 	if err == nil {
 		recovererErrorWriter.Write(out)
 	} else {
@@ -66,9 +75,8 @@ func PrintPrettyStack(rvr interface{}) {
 type prettyStack struct {
 }
 
-func (s prettyStack) parse(debugStack []byte, rvr interface{}) ([]byte, error) {
+func (s prettyStack) parse(debugStack []byte, rvr interface{}, useColor bool) ([]byte, error) {
 	var err error
-	useColor := true
 	buf := &bytes.Buffer{}
 
 	cW(buf, false, bRed, "\n")

--- a/middleware/recoverer_test.go
+++ b/middleware/recoverer_test.go
@@ -46,6 +46,13 @@ func TestRecoverer(t *testing.T) {
 }
 
 func TestRecovererNoColor(t *testing.T) {
+	// Force IsTTY so cW would emit color codes if useColor were true; this is
+	// what makes the assertion below a real regression guard rather than a
+	// no-op on non-TTY test runners (e.g. CI).
+	oldIsTTY := IsTTY
+	IsTTY = true
+	defer func() { IsTTY = oldIsTTY }()
+
 	oldRecovererErrorWriter := recovererErrorWriter
 	defer func() { recovererErrorWriter = oldRecovererErrorWriter }()
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
Follow-up to #1050, which fixed the core regression from #1042 (`defaultLogEntry.Panic()` ignored `DefaultLogFormatter.NoColor` because `PrintPrettyStack` hardcodes `useColor = true`).

This carries over the two remaining pieces from the other PRs on that issue, on top of the merged fix:

- **Doc comment** on the unexported `printPrettyStack`, explaining the `useColor` behavior (from #1086).
- **Hardened `TestRecovererNoColor`**: force `IsTTY = true` (saved/restored) so `cW` would emit ANSI codes if `useColor` were true. Without this the assertion is a no-op on non-TTY runners (e.g. CI) and passes even against the buggy code path — verified it fails when the bug is reintroduced. (from #1061)

It preserves @alliasgher's original #1086 commits via a merge commit so authorship is retained.

Supersedes #1041, #1061, #1086.

Fixes #1042.