### PR TITLE
fix: use exact token matching and respect q=0 in matchAcceptEncoding

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -239,11 +239,37 @@ func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, strin
 	return nil, "", func() {}
 }
 
+// matchAcceptEncoding reports whether encoding appears in the accepted list
+// with a non-zero quality value.
+//
+// Each element of accepted may contain an optional quality parameter, e.g.
+// "gzip;q=0.8" or "gzip;q=0". Per RFC 9110 section 12.5.3, a quality value
+// of 0 means the encoding is explicitly not acceptable and must be rejected.
+// Matching is done by exact token comparison (not substring) so that, for
+// example, "br" does not accidentally match the encoding "b".
 func matchAcceptEncoding(accepted []string, encoding string) bool {
 	for _, v := range accepted {
-		if strings.Contains(v, encoding) {
+		v = strings.TrimSpace(v)
+		// Split off any parameters (e.g. ";q=0.5").
+		parts := strings.SplitN(v, ";", 2)
+		token := strings.TrimSpace(parts[0])
+		if token != encoding {
+			continue
+		}
+		// Encoding token matches. Check the quality value if present.
+		if len(parts) == 1 {
+			// No quality parameter; default quality is 1 (acceptable).
 			return true
 		}
+		// Parse the quality parameter.
+		param := strings.TrimSpace(parts[1])
+		if strings.HasPrefix(param, "q=") {
+			q := strings.TrimPrefix(param, "q=")
+			if q == "0" || q == "0.0" || q == "0.00" || q == "0.000" {
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -215,3 +215,102 @@ func decodeResponseBody(t *testing.T, resp *http.Response) string {
 
 	return string(respBody)
 }
+
+func TestMatchAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		accepted []string
+		encoding string
+		want     bool
+	}{
+		// Exact match
+		{
+			name:     "exact match gzip",
+			accepted: []string{"gzip"},
+			encoding: "gzip",
+			want:     true,
+		},
+		// Substring false positives that previously returned true
+		{
+			name:     "br does not match b",
+			accepted: []string{"br"},
+			encoding: "b",
+			want:     false,
+		},
+		{
+			name:     "bgzip does not match gzip",
+			accepted: []string{"bgzip"},
+			encoding: "gzip",
+			want:     false,
+		},
+		// q=0 must be rejected (client explicitly refuses the encoding)
+		{
+			name:     "gzip;q=0 is not acceptable",
+			accepted: []string{"gzip;q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		{
+			name:     "gzip;q=0.0 is not acceptable",
+			accepted: []string{"gzip;q=0.0"},
+			encoding: "gzip",
+			want:     false,
+		},
+		// Non-zero quality values are acceptable
+		{
+			name:     "gzip;q=1 is acceptable",
+			accepted: []string{"gzip;q=1"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "gzip;q=0.5 is acceptable",
+			accepted: []string{"gzip;q=0.5"},
+			encoding: "gzip",
+			want:     true,
+		},
+		// Multiple accepted encodings
+		{
+			name:     "encoding in list",
+			accepted: []string{"deflate", "gzip", "br"},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "encoding not in list",
+			accepted: []string{"deflate", "br"},
+			encoding: "gzip",
+			want:     false,
+		},
+		// Empty list
+		{
+			name:     "empty accepted list",
+			accepted: []string{""},
+			encoding: "gzip",
+			want:     false,
+		},
+		// Whitespace trimming
+		{
+			name:     "leading/trailing whitespace around token",
+			accepted: []string{" gzip "},
+			encoding: "gzip",
+			want:     true,
+		},
+		{
+			name:     "whitespace around quality param",
+			accepted: []string{"gzip ; q=0"},
+			encoding: "gzip",
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchAcceptEncoding(tc.accepted, tc.encoding)
+			if got != tc.want {
+				t.Errorf("matchAcceptEncoding(%v, %q) = %v, want %v",
+					tc.accepted, tc.encoding, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `matchAcceptEncoding` helper in `middleware/compress.go` used `strings.Contains` to test whether an encoding appears in the `Accept-Encoding` header. This caused two correctness bugs:

**1. Substring false positives**

`strings.Contains("br", "b")` returns `true`, so a client sending `Accept-Encoding: br` would be matched by the encoding `"b"`. Similarly, `"bgzip"` incorrectly matched `"gzip"`.

**2. `q=0` ignored**

Per [RFC 9110 section 12.5.3](https://httpwg.org/specs/rfc9110.html#field.accept-encoding), a quality value of `0` means the encoding is **not acceptable**. The old code matched `"gzip;q=0"` as if gzip were acceptable, causing the middleware to compress with an encoding the client explicitly refused.

## Changes

**`middleware/compress.go`**

Rewrote `matchAcceptEncoding` to:
- Split each header token on `";"` to separate the encoding name from quality parameters
- Trim whitespace around both the token and the parameter
- Compare the encoding name with exact string equality (not substring)
- Reject the match when the quality parameter is `q=0` (or equivalent `0.0`, `0.00`, `0.000`)

**`middleware/compress_test.go`**

Added `TestMatchAcceptEncoding` with table-driven cases covering:
- Exact match
- Substring false positives (`"br"` vs `"b"`, `"bgzip"` vs `"gzip"`)
- `q=0` rejection
- Non-zero quality values (`q=1`, `q=0.5`)
- Multiple accepted encodings
- Empty accepted list
- Whitespace trimming

## Testing

```
$ go test ./...
ok  github.com/go-chi/chi/v5            3.5s
ok  github.com/go-chi/chi/v5/middleware 27.6s
```

Fixes #1069