### PR TITLE
docs: fix typo cancelation -> cancellation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 `chi` is a lightweight, idiomatic and composable router for building Go HTTP services. It's
 especially good at helping you write large REST API services that are kept maintainable as your
 project grows and changes. `chi` is built on the new `context` package introduced in Go 1.7 to
-handle signaling, cancelation and request-scoped values across a handler chain.
+handle signaling, cancellation and request-scoped values across a handler chain.
 
 The focus of the project has been to seek out an elegant and comfortable design for writing
 REST API servers, written during the development of the Pressly API service that powers our


### PR DESCRIPTION
Line 9 of the README has `cancelation` (one `l`), while the correct spelling is `cancellation` (two `l`s). Line 34 of the same file already uses the correct form.

Fix: `cancelation` → `cancellation`