### PR TITLE
fix(router): optional StrictRouting for static 405 precedence

### DIFF
--- a/context.go
+++ b/context.go
@@ -76,6 +76,9 @@ type Context struct {
 
 	methodsAllowed   []methodTyp // allowed methods in case of a 405
 	methodNotAllowed bool
+	// strictStaticMethodMatch prefers 405 on exact static path matches over
+	// falling through to less-specific param/regexp siblings (see Mux.StrictRouting).
+	strictStaticMethodMatch bool
 }
 
 // Reset a routing context to its initial state.
@@ -91,6 +94,7 @@ func (x *Context) Reset() {
 	x.routeParams.Keys = x.routeParams.Keys[:0]
 	x.routeParams.Values = x.routeParams.Values[:0]
 	x.methodNotAllowed = false
+	x.strictStaticMethodMatch = false
 	x.methodsAllowed = x.methodsAllowed[:0]
 	x.parentCtx = nil
 }

--- a/mux.go
+++ b/mux.go
@@ -45,6 +45,10 @@ type Mux struct {
 	// Controls the behaviour of middleware chain generation when a mux
 	// is registered as an inline group inside another mux.
 	inline bool
+
+	// When true, an exact static path that exists for other methods returns
+	// 405 instead of falling through to a param/regexp sibling (#1035).
+	strictRouting bool
 }
 
 // NewMux returns a newly initialized Mux object that implements the Router
@@ -216,6 +220,16 @@ func (mx *Mux) NotFound(handlerFn http.HandlerFunc) {
 			subMux.NotFound(hFn)
 		}
 	})
+}
+
+// StrictRouting controls whether an exact static path match that does not
+// support the request method returns 405 instead of falling through to a
+// less-specific param or regexp sibling route.
+//
+// Default is false to preserve historical chi behavior (e.g. GET /articles/me
+// may match /articles/{id} when only PUT is registered on /articles/me).
+func (mx *Mux) StrictRouting(enabled bool) {
+	mx.strictRouting = enabled
 }
 
 // MethodNotAllowed sets a custom http.HandlerFunc for routing paths where the
@@ -472,6 +486,7 @@ func (mx *Mux) routeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Find the route
+	rctx.strictStaticMethodMatch = mx.strictRouting
 	if _, _, h := mx.tree.FindRoute(rctx, method, routePath); h != nil {
 		// Set http.Request path values from our request context
 		for i, key := range rctx.URLParams.Keys {

--- a/mux_static_method_not_allowed_test.go
+++ b/mux_static_method_not_allowed_test.go
@@ -1,0 +1,52 @@
+package chi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Regression for #1035: a static path that exists for some methods must not
+// fall through to a sibling param route when the request method is unsupported.
+func TestStaticRouteMethodNotAllowedOverParam(t *testing.T) {
+	r := NewRouter()
+	r.StrictRouting(true)
+	r.Get("/users", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("list"))
+	})
+	r.Get("/users/me", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("me"))
+	})
+	r.Get("/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("id=" + URLParam(r, "id")))
+	})
+	r.Put("/users/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("put=" + URLParam(r, "id")))
+	})
+
+	ts := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/users/me", nil)
+	r.ServeHTTP(ts, req)
+	if ts.Code != 200 || ts.Body.String() != "me" {
+		t.Fatalf("GET /users/me: got %d %q", ts.Code, ts.Body.String())
+	}
+
+	// PUT /users/me must be 405, not PUT /users/{id} with id=me
+	ts = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/users/me", nil)
+	r.ServeHTTP(ts, req)
+	if ts.Code != 405 {
+		t.Fatalf("PUT /users/me: want 405, got %d body=%q", ts.Code, ts.Body.String())
+	}
+	if ts.Body.String() != "" && ts.Body.String() == "put=me" {
+		t.Fatalf("PUT /users/me fell through to param route: body=%q", ts.Body.String())
+	}
+
+	// PUT /users/123 still hits param route
+	ts = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/users/123", nil)
+	r.ServeHTTP(ts, req)
+	if ts.Code != 200 || ts.Body.String() != "put=123" {
+		t.Fatalf("PUT /users/123: got %d %q", ts.Code, ts.Body.String())
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -530,6 +530,12 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 				// flag that the routing context found a route, but not a corresponding
 				// supported method
 				rctx.methodNotAllowed = true
+
+				// Optional: exact static path match takes precedence over less-specific
+				// param/regexp siblings when Mux.StrictRouting is enabled (#1035).
+				if xn.typ == ntStatic && rctx.strictStaticMethodMatch {
+					return nil
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
If `/users/me` is registered for GET and `/users/{id}` for PUT, a `PUT /users/me` currently falls through to the param route (`id=me`) instead of returning 405 for the exact static path (#1035).

Historical chi behavior (see `TestTreeMoar`) intentionally allows method fallthrough to param siblings in some cases, so this is **opt-in**.

## Fix
- Add `Mux.StrictRouting(bool)`
- When enabled, an exact static leaf that matches the path but not the method sets 405 and stops searching less-specific param/regexp siblings

## Test plan
- [x] `go test ./...`
- [x] New `TestStaticRouteMethodNotAllowedOverParam` (with `StrictRouting(true)`)
- [x] Existing `TestTreeMoar` still passes with default (false)

Fixes #1035