### PR TITLE
docs(middleware): fix xml case label in URLFormat example

### DIFF
--- a/middleware/url_format.go
+++ b/middleware/url_format.go
@@ -37,7 +37,7 @@ var (
 //		switch urlFormat {
 //		case "json":
 //			render.JSON(w, r, articles)
-//		case "xml:"
+//		case "xml"
 //			render.XML(w, r, articles)
 //		default:
 //			render.JSON(w, r, articles)


### PR DESCRIPTION
Godoc used `case "xml:"` which never matches format `xml`.