### PR TITLE
fix(middleware): parse comma-separated Content-Encoding values

### DIFF
--- a/middleware/content_encoding.go
+++ b/middleware/content_encoding.go
@@ -20,11 +20,17 @@ func AllowContentEncoding(contentEncoding ...string) func(next http.Handler) htt
 				next.ServeHTTP(w, r)
 				return
 			}
-			// All encodings in the request must be allowed
-			for _, encoding := range requestEncodings {
-				if _, ok := allowedEncodings[strings.TrimSpace(strings.ToLower(encoding))]; !ok {
-					w.WriteHeader(http.StatusUnsupportedMediaType)
-					return
+			// All encodings in the request must be allowed (header values may be comma-separated).
+			for _, headerVal := range requestEncodings {
+				for _, encoding := range strings.Split(headerVal, ",") {
+					encoding = strings.TrimSpace(strings.ToLower(encoding))
+					if encoding == "" {
+						continue
+					}
+					if _, ok := allowedEncodings[encoding]; !ok {
+						w.WriteHeader(http.StatusUnsupportedMediaType)
+						return
+					}
 				}
 			}
 			next.ServeHTTP(w, r)

--- a/middleware/content_encoding_test.go
+++ b/middleware/content_encoding_test.go
@@ -54,6 +54,16 @@ func TestContentEncodingMiddleware(t *testing.T) {
 			encodings:      []string{"deflate", "br"},
 			expectedStatus: 415,
 		},
+		{
+			name:           "Support comma-separated gzip, deflate",
+			encodings:      []string{"gzip, deflate"},
+			expectedStatus: 200,
+		},
+		{
+			name:           "No support for comma-separated gzip, br",
+			encodings:      []string{"gzip, br"},
+			expectedStatus: 415,
+		},
 	}
 
 	for _, tt := range tests {
@@ -64,7 +74,7 @@ func TestContentEncodingMiddleware(t *testing.T) {
 			body := []byte("This is my content. There are many like this but this one is mine")
 			r := httptest.NewRequest("POST", "/", bytes.NewReader(body))
 			for _, encoding := range tt.encodings {
-				r.Header.Set("Content-Encoding", encoding)
+				r.Header.Add("Content-Encoding", encoding)
 			}
 
 			w := httptest.NewRecorder()


### PR DESCRIPTION
Split Content-Encoding on commas; fix multi-value tests.