### PR TITLE
fix(middleware): Accept-Encoding matching and HEAD in 405 Allow

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -239,11 +240,46 @@ func (c *Compressor) selectEncoder(h http.Header, w io.Writer) (io.Writer, strin
 	return nil, "", func() {}
 }
 
+// matchAcceptEncoding reports whether encoding is acceptable according to
+// the parsed Accept-Encoding tokens (already lowercased, comma-split).
+// Tokens may include quality values (e.g. "gzip;q=0.8"). Per RFC 9110,
+// q=0 means "not acceptable". Matching is by encoding name only (not a
+// substring of the full token), so "br" does not match encoding "b".
 func matchAcceptEncoding(accepted []string, encoding string) bool {
+	encoding = strings.ToLower(encoding)
 	for _, v := range accepted {
-		if strings.Contains(v, encoding) {
-			return true
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
 		}
+		// Split name from parameters (q=, etc.)
+		name, params, _ := strings.Cut(v, ";")
+		name = strings.TrimSpace(name)
+		if name != encoding && name != "*" {
+			continue
+		}
+		// Default q=1 when omitted; q=0 means not acceptable.
+		q := 1.0
+		for _, p := range strings.Split(params, ";") {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			key, val, ok := strings.Cut(p, "=")
+			if !ok {
+				continue
+			}
+			if strings.TrimSpace(key) != "q" {
+				continue
+			}
+			if f, err := strconv.ParseFloat(strings.TrimSpace(val), 64); err == nil {
+				q = f
+			}
+		}
+		if q <= 0 {
+			return false
+		}
+		return true
 	}
 	return false
 }

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -215,3 +215,28 @@ func decodeResponseBody(t *testing.T, resp *http.Response) string {
 
 	return string(respBody)
 }
+
+func TestMatchAcceptEncoding(t *testing.T) {
+	tests := []struct {
+		accepted []string
+		encoding string
+		want     bool
+	}{
+		{[]string{"gzip"}, "gzip", true},
+		{[]string{"gzip;q=1.0"}, "gzip", true},
+		{[]string{"gzip;q=0"}, "gzip", false},
+		{[]string{"gzip;q=0.0"}, "gzip", false},
+		{[]string{"br"}, "gzip", false},
+		{[]string{"br"}, "b", false},          // no substring false positive
+		{[]string{"bgzip"}, "gzip", false},    // no substring false positive
+		{[]string{"gzip", "deflate"}, "deflate", true},
+		{[]string{"*"}, "gzip", true},
+		{[]string{"*;q=0"}, "gzip", false},
+		{[]string{" gzip ; q=0.8 "}, "gzip", true},
+	}
+	for _, tt := range tests {
+		if got := matchAcceptEncoding(tt.accepted, tt.encoding); got != tt.want {
+			t.Errorf("matchAcceptEncoding(%v, %q)=%v want %v", tt.accepted, tt.encoding, got, tt.want)
+		}
+	}
+}

--- a/mux.go
+++ b/mux.go
@@ -523,8 +523,21 @@ func (mx *Mux) updateRouteHandler() {
 // methods for the route.
 func methodNotAllowedHandler(methodsAllowed ...methodTyp) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		hasGET, hasHEAD := false, false
 		for _, m := range methodsAllowed {
+			if m == mGET {
+				hasGET = true
+			}
+			if m == mHEAD {
+				hasHEAD = true
+			}
 			w.Header().Add("Allow", reverseMethodMap[m])
+		}
+		// RFC 9110: HEAD is the same as GET without a body. When GET is
+		// allowed, advertise HEAD so clients and GetHead middleware stay
+		// consistent with the Allow header.
+		if hasGET && !hasHEAD {
+			w.Header().Add("Allow", http.MethodHead)
 		}
 		w.WriteHeader(405)
 		w.Write(nil)

--- a/mux_test.go
+++ b/mux_test.go
@@ -2120,3 +2120,30 @@ func BenchmarkMux(b *testing.B) {
 		})
 	}
 }
+
+func TestMethodNotAllowedAllowIncludesHEADForGET(t *testing.T) {
+	r := NewRouter()
+	r.Get("/only-get", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	resp, _ := testRequest(t, ts, "POST", "/only-get", nil)
+	if resp.StatusCode != 405 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	allowed := resp.Header.Values("Allow")
+	hasGET, hasHEAD := false, false
+	for _, m := range allowed {
+		if m == "GET" {
+			hasGET = true
+		}
+		if m == "HEAD" {
+			hasHEAD = true
+		}
+	}
+	if !hasGET || !hasHEAD {
+		t.Fatalf("Allow should include GET and HEAD, got %v", allowed)
+	}
+}


### PR DESCRIPTION
## Summary

Two related HTTP correctness fixes:

1. **`matchAcceptEncoding` (#1069)**  
   - Stop using substring match (`"br"` no longer matches encoding `"b"`)  
   - Honor `q=0` as “not acceptable” per RFC 9110  
   - Still supports `*` and quality parameters

2. **405 `Allow` header (#1030 related)**  
   When a route allows `GET` but not an explicit `HEAD`, advertise `HEAD` as well so clients and `middleware.GetHead` stay consistent with RFC 9110 (HEAD is GET without a body).

## Test plan

- [x] `go test -run TestMatchAcceptEncoding`
- [x] `go test -run TestMethodNotAllowed`