### PR TITLE
feat: named catch-all path params {name:*} (incl. mid-route)

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -738,6 +738,18 @@ func patNextSegment(pattern string) (nodeTyp, string, string, byte, int, int) {
 
 		key, rexpat, isRegexp := strings.Cut(key, ":")
 		if isRegexp {
+			// Named catch-all: {path:*} matches the remainder of the URL path
+			// (including slashes) and records it under URLParam "path".
+			// Like "*", it must be the final segment in the pattern.
+			if rexpat == "*" {
+				if pe < len(pattern) {
+					panic("chi: named catch-all '{param:*}' must be the last segment in a route")
+				}
+				if key == "" {
+					panic("chi: named catch-all requires a non-empty param name, e.g. '{path:*}'")
+				}
+				return ntCatchAll, key, "", 0, ps, pe
+			}
 			nt = ntRegexp
 		}
 

--- a/tree.go
+++ b/tree.go
@@ -273,11 +273,11 @@ func (n *node) addChild(child *node, prefix string) *node {
 			// Route starts with a param
 			child.typ = segTyp
 
-			if segTyp == ntCatchAll {
-				segStartIdx = -1
-			} else {
-				segStartIdx = segEndIdx
-			}
+			// Named catch-all may be followed by a static suffix
+			// (e.g. /files/{path:*}/edit). Bare /* still ends the pattern
+			// (enforced in patNextSegment). Use the segment end so trailing
+			// static edges are attached as children of the catch-all node.
+			segStartIdx = segEndIdx
 			if segStartIdx < 0 {
 				segStartIdx = len(search)
 			}
@@ -501,9 +501,46 @@ func (n *node) findRoute(rctx *Context, method methodTyp, path string) *node {
 			rctx.routeParams.Values = append(rctx.routeParams.Values, "")
 
 		default:
-			// catch-all nodes
-			rctx.routeParams.Values = append(rctx.routeParams.Values, search)
+			// catch-all nodes: either consume the remainder (leaf /* or
+			// {name:*}), or leave a suffix for children when the pattern is
+			// mid-route, e.g. /files/{path:*}/edit.
 			xn = nds[0]
+			prevlen := len(rctx.routeParams.Values)
+
+			hasChild := false
+			for _, kids := range xn.children {
+				if len(kids) > 0 {
+					hasChild = true
+					break
+				}
+			}
+
+			if hasChild {
+				// Greedy: try longest catch-all value first so
+				// /files/a/b/edit binds path=a/b with suffix /edit.
+				for i := len(search); i >= 0; i-- {
+					rctx.routeParams.Values = append(rctx.routeParams.Values[:prevlen], search[:i])
+					fin := xn.findRoute(rctx, method, search[i:])
+					if fin != nil {
+						return fin
+					}
+				}
+				// Empty catch-all with a URL that has no extra slash before
+				// the suffix, e.g. pattern /files/{path:*}/upload and path
+				// /files/upload (path=""): remaining is "upload" but the
+				// static child is registered as "/upload".
+				if search != "" && search[0] != '/' {
+					rctx.routeParams.Values = append(rctx.routeParams.Values[:prevlen], "")
+					fin := xn.findRoute(rctx, method, "/"+search)
+					if fin != nil {
+						return fin
+					}
+				}
+				rctx.routeParams.Values = rctx.routeParams.Values[:prevlen]
+			}
+
+			// Leaf catch-all (or no child matched): take the entire remainder.
+			rctx.routeParams.Values = append(rctx.routeParams.Values, search)
 			xsearch = ""
 		}
 
@@ -738,13 +775,11 @@ func patNextSegment(pattern string) (nodeTyp, string, string, byte, int, int) {
 
 		key, rexpat, isRegexp := strings.Cut(key, ":")
 		if isRegexp {
-			// Named catch-all: {path:*} matches the remainder of the URL path
-			// (including slashes) and records it under URLParam "path".
-			// Like "*", it must be the final segment in the pattern.
+			// Named catch-all: {path:*} matches zero or more path segments
+			// (including slashes) and records them under URLParam key.
+			// May be followed by a static suffix, e.g. /files/{path:*}/edit.
+			// Bare /* remains final-only (see below).
 			if rexpat == "*" {
-				if pe < len(pattern) {
-					panic("chi: named catch-all '{param:*}' must be the last segment in a route")
-				}
 				if key == "" {
 					panic("chi: named catch-all requires a non-empty param name, e.g. '{path:*}'")
 				}

--- a/wildcard_param_test.go
+++ b/wildcard_param_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 )
 
-// Named catch-all {name:*} (issue #1106) matches the remainder of the path
-// under a user-chosen param key instead of "*".
+// Named catch-all {name:*} (issue #1106) matches path segments (including
+// slashes) under a user-chosen param key. It may be terminal or mid-route
+// with a static suffix.
 func TestNamedCatchAllParam(t *testing.T) {
 	r := NewRouter()
 	r.Get("/files/{path:*}", func(w http.ResponseWriter, r *http.Request) {
@@ -45,21 +46,91 @@ func TestNamedCatchAllParam(t *testing.T) {
 	}
 }
 
-func TestNamedCatchAllMustBeLast(t *testing.T) {
+// Mid-route named catch-all: /files/{path:*}/edit etc. (issue #1106).
+func TestNamedCatchAllMidRoute(t *testing.T) {
+	r := NewRouter()
+	r.Get("/files/{path:*}/edit", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("edit:" + URLParam(r, "path")))
+	})
+	r.Delete("/files/{path:*}/delete", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("delete:" + URLParam(r, "path")))
+	})
+	r.Post("/files/{path:*}/upload", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("upload:" + URLParam(r, "path")))
+	})
+	// Terminal catch-all coexists and is less specific than /edit.
+	r.Get("/files/{path:*}", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("get:" + URLParam(r, "path")))
+	})
+
+	tests := []struct {
+		method string
+		path   string
+		want   string
+		code   int
+	}{
+		{http.MethodGet, "/files/one/two/three/four/edit", "edit:one/two/three/four", 200},
+		{http.MethodGet, "/files/foo/bar.txt/edit", "edit:foo/bar.txt", 200},
+		{http.MethodDelete, "/files/a/b/delete", "delete:a/b", 200},
+		// Empty path value: /files/upload → path=""
+		{http.MethodPost, "/files/upload", "upload:", 200},
+		// Terminal catch-all when no static suffix matches
+		{http.MethodGet, "/files/a/b/c", "get:a/b/c", 200},
+		// More specific /edit wins over terminal catch-all
+		{http.MethodGet, "/files/x/edit", "edit:x", 200},
+		// Unknown suffix
+		{http.MethodGet, "/files/a/b/unknown", "get:a/b/unknown", 200},
+		// Method not registered on mid-route leaf
+		{http.MethodGet, "/files/a/delete", "get:a/delete", 200},
+	}
+	for _, tc := range tests {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != tc.code {
+			t.Fatalf("%s %s: status %d want %d body=%q", tc.method, tc.path, rec.Code, tc.code, rec.Body.String())
+		}
+		if tc.code == 200 {
+			if got := rec.Body.String(); got != tc.want {
+				t.Fatalf("%s %s: got %q want %q", tc.method, tc.path, got, tc.want)
+			}
+		}
+	}
+}
+
+func TestBareWildcardMustStillBeLast(t *testing.T) {
 	defer func() {
 		if recover() == nil {
-			t.Fatal("expected panic for trailing text after named catch-all")
+			t.Fatal("expected panic for trailing text after bare *")
 		}
 	}()
 	r := NewRouter()
-	r.Get("/files/{path:*}/edit", func(w http.ResponseWriter, r *http.Request) {})
+	r.Get("/files/*/edit", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestNamedCatchAllEmptyNamePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for empty named catch-all key")
+		}
+	}()
+	r := NewRouter()
+	r.Get("/files/{:*}", func(w http.ResponseWriter, r *http.Request) {})
 }
 
 func TestPatNextSegmentNamedCatchAll(t *testing.T) {
-	nt, key, rex, _, _, _ := patNextSegment("/files/{path:*}")
+	nt, key, rex, _, _, pe := patNextSegment("/files/{path:*}")
 	if nt != ntCatchAll || key != "path" || rex != "" {
 		t.Fatalf("got typ=%v key=%q rex=%q", nt, key, rex)
 	}
+	_ = pe
+
+	// Mid-route: segment ends after }, remaining pattern is /edit
+	nt, key, _, _, ps, pe := patNextSegment("{path:*}/edit")
+	if nt != ntCatchAll || key != "path" || ps != 0 || pe != len("{path:*}") {
+		t.Fatalf("mid-route: typ=%v key=%q ps=%d pe=%d", nt, key, ps, pe)
+	}
+
 	keys := patParamKeys("/files/{path:*}")
 	if len(keys) != 1 || keys[0] != "path" {
 		t.Fatalf("keys=%v", keys)
@@ -67,5 +138,9 @@ func TestPatNextSegmentNamedCatchAll(t *testing.T) {
 	keys = patParamKeys("/a/{id}/{rest:*}")
 	if len(keys) != 2 || keys[0] != "id" || keys[1] != "rest" {
 		t.Fatalf("keys=%v", keys)
+	}
+	keys = patParamKeys("/files/{path:*}/edit")
+	if len(keys) != 1 || keys[0] != "path" {
+		t.Fatalf("mid-route keys=%v", keys)
 	}
 }

--- a/wildcard_param_test.go
+++ b/wildcard_param_test.go
@@ -1,0 +1,71 @@
+package chi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Named catch-all {name:*} (issue #1106) matches the remainder of the path
+// under a user-chosen param key instead of "*".
+func TestNamedCatchAllParam(t *testing.T) {
+	r := NewRouter()
+	r.Get("/files/{path:*}", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(URLParam(r, "path")))
+	})
+	r.Get("/assets/{id}/{rest:*}", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(URLParam(r, "id") + "|" + URLParam(r, "rest")))
+	})
+	// Existing bare * still works and records key "*".
+	r.Get("/legacy/*", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(URLParam(r, "*")))
+	})
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/files/", ""},
+		{"/files/a", "a"},
+		{"/files/a/b/c", "a/b/c"},
+		{"/files/foo/bar.txt", "foo/bar.txt"},
+		{"/assets/9/x/y", "9|x/y"},
+		{"/legacy/z/w", "z/w"},
+	}
+	for _, tc := range tests {
+		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: status %d", tc.path, rec.Code)
+		}
+		if got := rec.Body.String(); got != tc.want {
+			t.Fatalf("%s: got %q want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestNamedCatchAllMustBeLast(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for trailing text after named catch-all")
+		}
+	}()
+	r := NewRouter()
+	r.Get("/files/{path:*}/edit", func(w http.ResponseWriter, r *http.Request) {})
+}
+
+func TestPatNextSegmentNamedCatchAll(t *testing.T) {
+	nt, key, rex, _, _, _ := patNextSegment("/files/{path:*}")
+	if nt != ntCatchAll || key != "path" || rex != "" {
+		t.Fatalf("got typ=%v key=%q rex=%q", nt, key, rex)
+	}
+	keys := patParamKeys("/files/{path:*}")
+	if len(keys) != 1 || keys[0] != "path" {
+		t.Fatalf("keys=%v", keys)
+	}
+	keys = patParamKeys("/a/{id}/{rest:*}")
+	if len(keys) != 2 || keys[0] != "id" || keys[1] != "rest" {
+		t.Fatalf("keys=%v", keys)
+	}
+}


### PR DESCRIPTION
## Summary

Adds named catch-all path parameters `{name:*}` so multi-segment path values are captured under a real URLParam key (not only `"*"`).

Also supports **mid-route** static suffixes (the main request in #1106):

```go
r.Get("/files/{path:*}/edit", editHandler)
r.Delete("/files/{path:*}/delete", deleteHandler)
r.Post("/files/{path:*}/upload", uploadHandler)
r.Get("/files/{path:*}", getHandler)
```

| Request | Param |
|---------|--------|
| `GET /files/one/two/three/four/edit` | `path=one/two/three/four` |
| `GET /files/foo/bar.txt/edit` | `path=foo/bar.txt` |
| `POST /files/upload` | `path=` (empty) |
| `GET /files/a/b/c` | `path=a/b/c` (terminal catch-all) |

### Behavior

- `{path:*}` matches zero or more path segments (including `/`)
- Mid-route matching is **greedy**: longest catch-all value that still allows the static suffix to match
- Bare `/*` is unchanged and must still be the last segment
- Empty name `{:*} ` panics

Fixes #1106

## Test plan

- [x] `go test ./...`
- [x] Terminal named catch-all (`/files/{path:*}`)
- [x] Mid-route (`/files/{path:*}/edit`, `/delete`, `/upload`)
- [x] Coexistence with terminal catch-all on the same prefix
- [x] Bare `/*` still final-only