### PR TITLE
fix(middleware): parse comma-separated Content-Encoding values

### DIFF
--- a/middleware/content_encoding.go
+++ b/middleware/content_encoding.go
@@ -7,6 +7,9 @@ import (
 
 // AllowContentEncoding enforces a whitelist of request Content-Encoding otherwise responds
 // with a 415 Unsupported Media Type status.
+//
+// Content-Encoding may appear as multiple headers or as a single comma-separated
+// list (RFC 9110). Both forms are accepted; every listed encoding must be allowed.
 func AllowContentEncoding(contentEncoding ...string) func(next http.Handler) http.Handler {
 	allowedEncodings := make(map[string]struct{}, len(contentEncoding))
 	for _, encoding := range contentEncoding {
@@ -14,17 +17,23 @@ func AllowContentEncoding(contentEncoding ...string) func(next http.Handler) htt
 	}
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			requestEncodings := r.Header["Content-Encoding"]
 			// skip check for empty content body or no Content-Encoding
 			if r.ContentLength == 0 {
 				next.ServeHTTP(w, r)
 				return
 			}
-			// All encodings in the request must be allowed
-			for _, encoding := range requestEncodings {
-				if _, ok := allowedEncodings[strings.TrimSpace(strings.ToLower(encoding))]; !ok {
-					w.WriteHeader(http.StatusUnsupportedMediaType)
-					return
+			// All encodings in the request must be allowed. Split comma-separated
+			// lists so "Content-Encoding: gzip, deflate" is treated as two tokens.
+			for _, headerVal := range r.Header["Content-Encoding"] {
+				for _, encoding := range strings.Split(headerVal, ",") {
+					enc := strings.TrimSpace(strings.ToLower(encoding))
+					if enc == "" {
+						continue
+					}
+					if _, ok := allowedEncodings[enc]; !ok {
+						w.WriteHeader(http.StatusUnsupportedMediaType)
+						return
+					}
 				}
 			}
 			next.ServeHTTP(w, r)

--- a/middleware/content_encoding_test.go
+++ b/middleware/content_encoding_test.go
@@ -15,13 +15,16 @@ func TestContentEncodingMiddleware(t *testing.T) {
 	// support for:
 	// Content-Encoding: gzip
 	// Content-Encoding: deflate
-	// Content-Encoding: gzip, deflate
-	// Content-Encoding: deflate, gzip
+	// Content-Encoding: gzip, deflate   (comma-separated single header)
+	// Content-Encoding: gzip + Content-Encoding: deflate (multi header)
 	middleware := AllowContentEncoding("deflate", "gzip")
 
 	tests := []struct {
 		name           string
+		// set as single comma-joined Content-Encoding value when joinComma is true
 		encodings      []string
+		joinComma      bool
+		useAdd         bool // Add each encoding as separate header
 		expectedStatus int
 	}{
 		{
@@ -40,31 +43,73 @@ func TestContentEncodingMiddleware(t *testing.T) {
 			expectedStatus: 415,
 		},
 		{
-			name:           "Support for gzip and deflate encoding",
+			name:           "Support for gzip and deflate via separate headers",
 			encodings:      []string{"gzip", "deflate"},
+			useAdd:         true,
 			expectedStatus: 200,
 		},
 		{
-			name:           "Support for deflate and gzip encoding",
+			name:           "Support for deflate and gzip via separate headers",
 			encodings:      []string{"deflate", "gzip"},
+			useAdd:         true,
 			expectedStatus: 200,
 		},
 		{
-			name:           "No support for deflate and br encoding",
+			name:           "Support for comma-separated gzip, deflate",
+			encodings:      []string{"gzip", "deflate"},
+			joinComma:      true,
+			expectedStatus: 200,
+		},
+		{
+			name:           "Support for comma-separated deflate, gzip",
+			encodings:      []string{"deflate", "gzip"},
+			joinComma:      true,
+			expectedStatus: 200,
+		},
+		{
+			name:           "Comma-separated with spaces",
+			encodings:      []string{"gzip", "deflate"},
+			joinComma:      true,
+			expectedStatus: 200,
+		},
+		{
+			name:           "No support for deflate and br via separate headers",
 			encodings:      []string{"deflate", "br"},
+			useAdd:         true,
 			expectedStatus: 415,
+		},
+		{
+			name:           "No support for comma-separated deflate, br",
+			encodings:      []string{"deflate", "br"},
+			joinComma:      true,
+			expectedStatus: 415,
+		},
+		{
+			name:           "Case insensitive encoding names",
+			encodings:      []string{"GZip", "DEFLATE"},
+			joinComma:      true,
+			expectedStatus: 200,
 		},
 	}
 
 	for _, tt := range tests {
-		var tt = tt
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			body := []byte("This is my content. There are many like this but this one is mine")
 			r := httptest.NewRequest("POST", "/", bytes.NewReader(body))
-			for _, encoding := range tt.encodings {
-				r.Header.Set("Content-Encoding", encoding)
+			switch {
+			case tt.joinComma && len(tt.encodings) > 0:
+				r.Header.Set("Content-Encoding", joinWithCommaSpace(tt.encodings))
+			case tt.useAdd:
+				for _, encoding := range tt.encodings {
+					r.Header.Add("Content-Encoding", encoding)
+				}
+			default:
+				for _, encoding := range tt.encodings {
+					r.Header.Set("Content-Encoding", encoding)
+				}
 			}
 
 			w := httptest.NewRecorder()
@@ -79,4 +124,12 @@ func TestContentEncodingMiddleware(t *testing.T) {
 			}
 		})
 	}
+}
+
+func joinWithCommaSpace(parts []string) string {
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += ", " + parts[i]
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

`AllowContentEncoding` iterated `r.Header["Content-Encoding"]` and treated each map entry as one encoding name. When a client sends a single header with a comma-separated list:

```http
Content-Encoding: gzip, deflate
```

the Go `Header` map contains `["gzip, deflate"]` (one element). The middleware looked up the whole string and returned **415** even if both `gzip` and `deflate` were on the whitelist.

Per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-content-encoding), multiple content codings may appear as a comma-separated list or as repeated fields. This change splits each header value on commas and validates every token.

Also tightens the tests so multi-encoding cases use `Header.Add` (separate fields) or an explicit comma-joined value, instead of `Set` which overwrote previous values.

Closes #959

## Test plan

- [x] `go test ./middleware/ -run ContentEncoding`
- [x] `go test ./middleware/`
- [x] Covers: single encoding, multi-header, comma-separated, case folding, rejection of unknown tokens