### PR TITLE
Fix Walk for routes with handlers and subrouters

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -7,6 +7,7 @@ package chi
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -629,8 +630,9 @@ func (n *node) routes() []Route {
 	rts := []Route{}
 
 	n.walk(func(eps endpoints, subroutes Routes) bool {
-		if eps[mSTUB] != nil && eps[mSTUB].handler != nil && subroutes == nil {
-			return false
+		var stubHandler http.Handler
+		if eps[mSTUB] != nil {
+			stubHandler = eps[mSTUB].handler
 		}
 
 		// Group methodHandlers by unique patterns
@@ -650,12 +652,13 @@ func (n *node) routes() []Route {
 
 		for p, mh := range pats {
 			hs := make(map[string]http.Handler)
+
 			if mh[mALL] != nil && mh[mALL].handler != nil {
 				hs["*"] = mh[mALL].handler
 			}
 
 			for mt, h := range mh {
-				if h.handler == nil {
+				if h.handler == nil || sameHandler(h.handler, stubHandler) {
 					continue
 				}
 				if m, ok := reverseMethodMap[mt]; ok {
@@ -671,6 +674,28 @@ func (n *node) routes() []Route {
 	})
 
 	return rts
+}
+
+func sameHandler(a, b http.Handler) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Type() != bv.Type() {
+		return false
+	}
+
+	switch av.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		return av.Pointer() == bv.Pointer()
+	default:
+		if av.Type().Comparable() {
+			return a == b
+		}
+		return false
+	}
 }
 
 func (n *node) walk(fn func(eps endpoints, subroutes Routes) bool) bool {
@@ -848,16 +873,16 @@ func walk(r Routes, walkFn WalkFunc, parentRoute string, parentMw ...func(http.H
 		mws := slices.Concat(parentMw, r.Middlewares())
 
 		if route.SubRoutes != nil {
+			subrouteMw := mws
 			if handler, ok := route.Handlers["*"]; ok {
 				if chain, ok := handler.(*ChainHandler); ok {
-					mws = append(mws, chain.Middlewares...)
+					subrouteMw = append(subrouteMw, chain.Middlewares...)
 				}
 			}
 
-			if err := walk(route.SubRoutes, walkFn, parentRoute+route.Pattern, mws...); err != nil {
+			if err := walk(route.SubRoutes, walkFn, parentRoute+route.Pattern, subrouteMw...); err != nil {
 				return err
 			}
-			continue
 		}
 
 		for method, handler := range route.Handlers {

--- a/tree_test.go
+++ b/tree_test.go
@@ -522,6 +522,32 @@ func TestWalker(t *testing.T) {
 	}
 }
 
+func TestWalkRouteWithHandlerAndSubrouter(t *testing.T) {
+	r := NewRouter()
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	r.Route("/foo", func(r Router) {
+		r.Route("/bar", func(r Router) {
+			r.Get("/{id}", handler)
+		})
+		r.Get("/bar", handler)
+	})
+
+	routes := map[string]bool{}
+	if err := Walk(r, func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+		routes[method+" "+route] = true
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, route := range []string{"GET /foo/bar", "GET /foo/bar/{id}"} {
+		if !routes[route] {
+			t.Fatalf("expected Walk to include %s, got %v", route, routes)
+		}
+	}
+}
+
 func TestWalkInlineMiddlewaresAcrossSubrouter(t *testing.T) {
 	mw := func(next http.Handler) http.Handler { return next }
 	handler := func(w http.ResponseWriter, r *http.Request) {}


### PR DESCRIPTION
Fixes #830

## Reproduction
Register a handler and a subrouter on the same Route() pattern:

```go
r.Route("/foo", func(r chi.Router) {
    r.Route("/bar", func(r chi.Router) {
        r.Get("/{id}", handler)
    })
    r.Get("/bar", handler)
})
```

`GET /foo/bar` is routable, but `chi.Walk` only reported `GET /foo/bar/{id}` and omitted `GET /foo/bar`.

## Root cause
`walk` returned immediately after descending into `route.SubRoutes`, so any real handlers stored on that same route entry were skipped. The route tree also uses stub endpoints for mount connectors; those synthetic handlers need to remain hidden from public route listings.

## Fix
Continue walking handlers after subroutes, while keeping subrouter middleware propagation separate. `routes()` now filters synthetic stub handlers but preserves the internal `*` handler used to carry inline middleware into subrouters.

## Compatibility
No API changes and no new dependencies. This only makes `Walk`/`Routes` report an already-routable handler that was previously omitted; synthetic mount connector routes remain hidden.

## Validation
- Regression test `go test . -run TestWalkRouteWithHandlerAndSubrouter -count=1` fails without the fix: `expected Walk to include GET /foo/bar, got map[GET /foo/bar/{id}:true]`.
- `go build ./...` passed.
- `go vet ./...` passed.
- `gofmt -l .` produced no output.
- `go test ./...` passed (`github.com/go-chi/chi/v5`, `github.com/go-chi/chi/v5/middleware`).