### PR TITLE
fix: don't drop handlers that collide with a Mount()/Route() pattern

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -657,13 +657,13 @@ func (n *node) routes() []Route {
 			// Walk() reads Handlers["*"] for With() middleware when recursing
 			// into a subroute, so keep it there even if it's also the stub.
 			if mh[mALL] != nil && mh[mALL].handler != nil {
-				if subroutes != nil || !sameHandler(mh[mALL].handler, stubHandler) {
+				if subroutes != nil || !equalHandlers(mh[mALL].handler, stubHandler) {
 					hs["*"] = mh[mALL].handler
 				}
 			}
 
 			for mt, h := range mh {
-				if h.handler == nil || sameHandler(h.handler, stubHandler) {
+				if h.handler == nil || equalHandlers(h.handler, stubHandler) {
 					continue
 				}
 				if m, ok := reverseMethodMap[mt]; ok {
@@ -686,10 +686,10 @@ func (n *node) routes() []Route {
 	return rts
 }
 
-// sameHandler reports whether a and b are the same handler value. Handlers
-// are commonly funcs, so this uses reflection: a direct == panics on
-// uncomparable types such as http.HandlerFunc.
-func sameHandler(a, b http.Handler) bool {
+// equalHandlers reports whether a and b are the same handler value. Handlers
+// are commonly funcs (e.g. http.HandlerFunc), and a direct == on those
+// panics at runtime, so funcs are compared by pointer instead.
+func equalHandlers(a, b http.Handler) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
@@ -700,15 +700,13 @@ func sameHandler(a, b http.Handler) bool {
 		return false
 	}
 
-	switch av.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+	if av.Kind() == reflect.Func {
 		return av.Pointer() == bv.Pointer()
-	default:
-		if av.Type().Comparable() {
-			return a == b
-		}
-		return false
 	}
+	if av.Type().Comparable() {
+		return a == b
+	}
+	return false
 }
 
 func (n *node) walk(fn func(eps endpoints, subroutes Routes) bool) bool {

--- a/tree.go
+++ b/tree.go
@@ -630,11 +630,7 @@ func (n *node) routes() []Route {
 	rts := []Route{}
 
 	n.walk(func(eps endpoints, subroutes Routes) bool {
-		// Mount() registers a synthetic stub handler on the exact mount
-		// pattern to connect it to the subrouter. That stub must stay
-		// hidden from the public route listing, but a real handler
-		// registered on the very same pattern (e.g. a Get() colliding
-		// with a Route() mount) must still be reported.
+		// Hide Mount()'s stub handler, but not a real handler sharing its pattern.
 		var stubHandler http.Handler
 		if eps[mSTUB] != nil {
 			stubHandler = eps[mSTUB].handler
@@ -658,11 +654,8 @@ func (n *node) routes() []Route {
 		for p, mh := range pats {
 			hs := make(map[string]http.Handler)
 
-			// Walk() reads Handlers["*"] to pick up inline (With()) middleware
-			// carried by a *ChainHandler when it recurses into a subroute, even
-			// when that same handler value is also the mount stub — so the "*"
-			// entry must stay in place whenever a subrouter is attached. It's
-			// only safe (and necessary) to hide it on a leaf, non-subroute node.
+			// Walk() reads Handlers["*"] for With() middleware when recursing
+			// into a subroute, so keep it there even if it's also the stub.
 			if mh[mALL] != nil && mh[mALL].handler != nil {
 				if subroutes != nil || !sameHandler(mh[mALL].handler, stubHandler) {
 					hs["*"] = mh[mALL].handler
@@ -678,10 +671,7 @@ func (n *node) routes() []Route {
 				}
 			}
 
-			// A node with subroutes must still be reported even when it
-			// carries no handlers of its own (Walk needs it to recurse
-			// into the subrouter); a leaf mount-connector stub with
-			// nothing left after filtering has nothing worth reporting.
+			// Keep subroute nodes so Walk() can recurse; a stub-only leaf has nothing to report.
 			if len(hs) == 0 && subroutes == nil {
 				continue
 			}
@@ -696,12 +686,9 @@ func (n *node) routes() []Route {
 	return rts
 }
 
-// sameHandler reports whether a and b are the same handler value. It is
-// used to detect the synthetic stub handler Mount() installs on its mount
-// pattern so routes() can hide it without dropping a real handler that
-// happens to share the same node. Handlers are commonly funcs, which are
-// only comparable via reflection (a direct == panics on uncomparable
-// types such as http.HandlerFunc).
+// sameHandler reports whether a and b are the same handler value. Handlers
+// are commonly funcs, so this uses reflection: a direct == panics on
+// uncomparable types such as http.HandlerFunc.
 func sameHandler(a, b http.Handler) bool {
 	if a == nil || b == nil {
 		return a == b

--- a/tree.go
+++ b/tree.go
@@ -7,6 +7,7 @@ package chi
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -629,8 +630,14 @@ func (n *node) routes() []Route {
 	rts := []Route{}
 
 	n.walk(func(eps endpoints, subroutes Routes) bool {
-		if eps[mSTUB] != nil && eps[mSTUB].handler != nil && subroutes == nil {
-			return false
+		// Mount() registers a synthetic stub handler on the exact mount
+		// pattern to connect it to the subrouter. That stub must stay
+		// hidden from the public route listing, but a real handler
+		// registered on the very same pattern (e.g. a Get() colliding
+		// with a Route() mount) must still be reported.
+		var stubHandler http.Handler
+		if eps[mSTUB] != nil {
+			stubHandler = eps[mSTUB].handler
 		}
 
 		// Group methodHandlers by unique patterns
@@ -650,17 +657,33 @@ func (n *node) routes() []Route {
 
 		for p, mh := range pats {
 			hs := make(map[string]http.Handler)
+
+			// Walk() reads Handlers["*"] to pick up inline (With()) middleware
+			// carried by a *ChainHandler when it recurses into a subroute, even
+			// when that same handler value is also the mount stub — so the "*"
+			// entry must stay in place whenever a subrouter is attached. It's
+			// only safe (and necessary) to hide it on a leaf, non-subroute node.
 			if mh[mALL] != nil && mh[mALL].handler != nil {
-				hs["*"] = mh[mALL].handler
+				if subroutes != nil || !sameHandler(mh[mALL].handler, stubHandler) {
+					hs["*"] = mh[mALL].handler
+				}
 			}
 
 			for mt, h := range mh {
-				if h.handler == nil {
+				if h.handler == nil || sameHandler(h.handler, stubHandler) {
 					continue
 				}
 				if m, ok := reverseMethodMap[mt]; ok {
 					hs[m] = h.handler
 				}
+			}
+
+			// A node with subroutes must still be reported even when it
+			// carries no handlers of its own (Walk needs it to recurse
+			// into the subrouter); a leaf mount-connector stub with
+			// nothing left after filtering has nothing worth reporting.
+			if len(hs) == 0 && subroutes == nil {
+				continue
 			}
 
 			rt := Route{subroutes, hs, p}
@@ -671,6 +694,34 @@ func (n *node) routes() []Route {
 	})
 
 	return rts
+}
+
+// sameHandler reports whether a and b are the same handler value. It is
+// used to detect the synthetic stub handler Mount() installs on its mount
+// pattern so routes() can hide it without dropping a real handler that
+// happens to share the same node. Handlers are commonly funcs, which are
+// only comparable via reflection (a direct == panics on uncomparable
+// types such as http.HandlerFunc).
+func sameHandler(a, b http.Handler) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	if av.Type() != bv.Type() {
+		return false
+	}
+
+	switch av.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return av.Pointer() == bv.Pointer()
+	default:
+		if av.Type().Comparable() {
+			return a == b
+		}
+		return false
+	}
 }
 
 func (n *node) walk(fn func(eps endpoints, subroutes Routes) bool) bool {

--- a/tree_test.go
+++ b/tree_test.go
@@ -622,13 +622,9 @@ func TestRoutesHidesMountStub(t *testing.T) {
 			r.Get("/{id}", handler)
 		})
 
-		// Routes() is not recursive: r.Route("/api", ...) mounts a distinct
-		// subrouter, so r.Routes() sees only the "/api/*" connector to it, not
-		// "/api/{id}". SubRoutes is itself a Routes, so it can be walked
-		// further — either manually via SubRoutes.Routes(), or by passing it
-		// straight to Walk() to recurse into just that subtree. Walk() itself
-		// already does this recursion across the whole tree, which is how it
-		// correctly reports "/api/{id}" (see TestWalkRouteWithHandlerAndSubrouter).
+		// Routes() isn't recursive: /api mounts a separate subrouter, so only
+		// its "/api/*" connector shows here, not "/api/{id}". SubRoutes can be
+		// walked further, the same way Walk() does internally.
 		routes := r.Routes()
 		if len(routes) != 1 {
 			t.Fatalf("expected exactly 1 route, got %d: %+v", len(routes), routes)

--- a/tree_test.go
+++ b/tree_test.go
@@ -622,6 +622,13 @@ func TestRoutesHidesMountStub(t *testing.T) {
 			r.Get("/{id}", handler)
 		})
 
+		// Routes() is not recursive: r.Route("/api", ...) mounts a distinct
+		// subrouter, so r.Routes() sees only the "/api/*" connector to it, not
+		// "/api/{id}". SubRoutes is itself a Routes, so it can be walked
+		// further — either manually via SubRoutes.Routes(), or by passing it
+		// straight to Walk() to recurse into just that subtree. Walk() itself
+		// already does this recursion across the whole tree, which is how it
+		// correctly reports "/api/{id}" (see TestWalkRouteWithHandlerAndSubrouter).
 		routes := r.Routes()
 		if len(routes) != 1 {
 			t.Fatalf("expected exactly 1 route, got %d: %+v", len(routes), routes)

--- a/tree_test.go
+++ b/tree_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -575,5 +577,136 @@ func TestWalkInlineMiddlewaresAcrossSubrouter(t *testing.T) {
 				t.Fatalf("expected %d middlewares, got %d", tt.expected, middlewareCount)
 			}
 		})
+	}
+}
+
+// https://github.com/go-chi/chi/issues/830
+func TestWalkRouteWithHandlerAndSubrouter(t *testing.T) {
+	r := NewRouter()
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	r.Route("/foo", func(r Router) {
+		r.Route("/bar", func(r Router) {
+			r.Get("/{id}", handler)
+		})
+		r.Get("/bar", handler)
+	})
+
+	routes := map[string]bool{}
+	if err := Walk(r, func(method, route string, handler http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+		routes[method+" "+route] = true
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, route := range []string{"GET /foo/bar", "GET /foo/bar/{id}"} {
+		if !routes[route] {
+			t.Fatalf("expected Walk to include %s, got %v", route, routes)
+		}
+	}
+}
+
+// https://github.com/go-chi/chi/issues/830
+//
+// Routes() must not leak the synthetic stub handler Mount() installs on
+// its mount pattern: a plain Mount()/Route() should report exactly its
+// "/pattern/*" entry, and a handler that collides with a mount pattern
+// must be reported without also surfacing the internal stub under "*".
+func TestRoutesHidesMountStub(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	t.Run("plain mount reports a single subroute entry", func(t *testing.T) {
+		r := NewRouter()
+		r.Route("/api", func(r Router) {
+			r.Get("/{id}", handler)
+		})
+
+		routes := r.Routes()
+		if len(routes) != 1 {
+			t.Fatalf("expected exactly 1 route, got %d: %+v", len(routes), routes)
+		}
+		if routes[0].Pattern != "/api/*" || routes[0].SubRoutes == nil {
+			t.Fatalf("expected the single route to be the /api/* subroute, got %+v", routes[0])
+		}
+	})
+
+	t.Run("handler colliding with a mount pattern hides the stub", func(t *testing.T) {
+		r := NewRouter()
+		r.Route("/bar", func(r Router) {
+			r.Get("/{id}", handler)
+		})
+		r.Get("/bar", handler)
+
+		for _, rt := range r.Routes() {
+			if rt.Pattern != "/bar" {
+				continue
+			}
+			if rt.SubRoutes != nil {
+				t.Fatalf("expected /bar to have no subroutes of its own, got %+v", rt)
+			}
+			if len(rt.Handlers) != 1 {
+				t.Fatalf("expected /bar to report exactly the GET handler, got %v", rt.Handlers)
+			}
+			if _, ok := rt.Handlers[http.MethodGet]; !ok {
+				t.Fatalf("expected /bar to report a GET handler, got %v", rt.Handlers)
+			}
+		}
+	})
+}
+
+// https://github.com/go-chi/chi/issues/750
+//
+// Middlewares registered on a Group must still reach handlers defined on a
+// Route() mounted inside that group.
+func TestWalkMiddlewaresAcrossGroupAndRoute(t *testing.T) {
+	requestID := func(next http.Handler) http.Handler { return next }
+	timeout := func(next http.Handler) http.Handler { return next }
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	r := NewRouter()
+	r.Use(requestID)
+	r.Get("/A", handler)
+
+	r.Group(func(r Router) {
+		r.Use(timeout)
+		r.Get("/B", handler)
+		r.Route("/C", func(r Router) {
+			r.Get("/D", handler)
+		})
+	})
+
+	mwName := func(f func(http.Handler) http.Handler) string {
+		switch reflect.ValueOf(f).Pointer() {
+		case reflect.ValueOf(requestID).Pointer():
+			return "requestID"
+		case reflect.ValueOf(timeout).Pointer():
+			return "timeout"
+		default:
+			return "unknown"
+		}
+	}
+
+	got := map[string][]string{}
+	if err := Walk(r, func(method, route string, handler http.Handler, mws ...func(http.Handler) http.Handler) error {
+		names := make([]string, len(mws))
+		for i, m := range mws {
+			names[i] = mwName(m)
+		}
+		got[method+" "+route] = names
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string][]string{
+		"GET /A":   {"requestID"},
+		"GET /B":   {"requestID", "timeout"},
+		"GET /C/D": {"requestID", "timeout"},
+	}
+	for route, wantMws := range want {
+		if gotMws := got[route]; !slices.Equal(gotMws, wantMws) {
+			t.Fatalf("%s: expected middlewares %v, got %v", route, wantMws, gotMws)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #830: a handler sharing a pattern with a `Route()`/`Mount()` call was invisible to `Walk()`/`Routes()`, because the mount's internal stub handler caused the whole node to be hidden.

```go
r.Route("/foo", func(r chi.Router) {
    r.Route("/bar", func(r chi.Router) { r.Get("/{id}", h) })
    r.Get("/bar", h) // routable, but invisible to Walk
})
```

Builds on #1146 (thanks @deepakganesh78 for the diagnosis, repro, and the `sameHandler` idea), with two corrections found by testing `Routes()` directly instead of only `Walk`:

- Only hides the stub's `"*"` slot on leaf nodes — subroute nodes still need it, since `walk()` reads `Handlers["*"]` to pick up `With()` middleware from a `*ChainHandler`. #1146 hides it everywhere, which leaks two extra `Route` entries per `Mount()`/`Route()` call.
- Drops #1146's unrelated `walk()` change (`continue`/`subrouteMw`) — reverting just that half still passes everything.

Also adds a regression test for #750 (middlewares on a `Group()` not reaching a `Route()` mounted inside it) — already fixed on master, this just locks it in.

**Credits** — reported, diagnosed, or attempted a fix on these two issues:
- #830: [@sauerbraten](https://github.com/sauerbraten) (reported), [@ganicus](https://github.com/ganicus), [@lai0xn](https://github.com/lai0xn), [@deepakganesh78](https://github.com/deepakganesh78) (#1146)
- #750: [@ebabani](https://github.com/ebabani) (reported), [@pkieltyka](https://github.com/pkieltyka), [@ganicus](https://github.com/ganicus)

**Testing**: `TestWalkRouteWithHandlerAndSubrouter`, `TestRoutesHidesMountStub`, `TestWalkMiddlewaresAcrossGroupAndRoute`; `go build`/`vet`/`gofmt -l`/`test ./...` all clean.
