### PR TITLE
Document ServeHTTP, PrintPrettyStack and IsTTY

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -27,6 +27,10 @@ type ChainHandler struct {
 	Middlewares Middlewares
 }
 
+// ServeHTTP serves the middleware stack, ending at Endpoint. The stack is
+// composed once, when Middlewares.Handler or Middlewares.HandlerFunc builds
+// the ChainHandler, so assigning to Endpoint or Middlewares afterwards does
+// not change what is served.
 func (c *ChainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c.chain.ServeHTTP(w, r)
 }

--- a/middleware/recoverer.go
+++ b/middleware/recoverer.go
@@ -51,6 +51,10 @@ func Recoverer(next http.Handler) http.Handler {
 // for ability to test the PrintPrettyStack function
 var recovererErrorWriter io.Writer = os.Stderr
 
+// PrintPrettyStack writes a formatted stack trace for the recovered value rvr
+// to stderr, in color when [IsTTY] reports that stdout is a terminal.
+//
+// Recoverer calls this itself when the request carries no LogEntry.
 func PrintPrettyStack(rvr interface{}) {
 	printPrettyStack(rvr, true)
 }

--- a/middleware/terminal.go
+++ b/middleware/terminal.go
@@ -32,6 +32,10 @@ var (
 	reset = []byte{'\033', '[', '0', 'm'}
 )
 
+// IsTTY reports whether stdout looks like a terminal. It is set once during
+// package initialization, by treating stdout as a terminal when it is a
+// character device, and it gates the ANSI colors written by Logger and
+// Recoverer. Assign to it to force colors on or off.
 var IsTTY bool
 
 func init() {


### PR DESCRIPTION
Three exported identifiers have no doc comment, so [pkg.go.dev](https://pkg.go.dev/github.com/go-chi/chi/v5) shows them with an empty description while their neighbours are all described.

| Identifier | File |
| --- | --- |
| `(*ChainHandler).ServeHTTP` | `chain.go` |
| `PrintPrettyStack` | `middleware/recoverer.go` |
| `IsTTY` | `middleware/terminal.go` |

`PrintPrettyStack` is the clearest one. #1131 added a doc comment to the unexported `printPrettyStack`, and the diff there shows `func PrintPrettyStack(rvr interface{}) {` sitting in the context lines just above, still bare. The helper that users cannot call is documented, the wrapper they can call is not.

`(*ChainHandler).ServeHTTP` is the only bare export in `chain.go`; `Chain`, `Middlewares.Handler`, `Middlewares.HandlerFunc` and `ChainHandler` itself all have comments.

`IsTTY` is an exported package variable that gates the ANSI colors in `Logger` and `Recoverer`, and `recoverer_test.go` already assigns to it to force color on, so it is part of the surface people use.

### What the comments say

Everything in them is checked against the code rather than guessed:

- `chain` is assigned only in `Middlewares.Handler` and `Middlewares.HandlerFunc` and read only in `ServeHTTP`, so the stack really is composed once and later writes to `Endpoint` or `Middlewares` do not change what is served.
- `PrintPrettyStack` passes `useColor: true`, and `cW` emits color only when `IsTTY` is also true, so the comment says color happens when stdout is a terminal rather than always.
- `IsTTY` is set in `terminal.go`'s `init` from `os.Stdout.Stat()` against `ModeDevice|ModeCharDevice`, and `cW` is used from `logger.go` and `recoverer.go`, which is where the "Logger and Recoverer" wording comes from.

### Checks

`go build ./...`, `go vet ./...` and `go test ./...` all pass, and `go doc` renders each of the three.

A note on `gofmt`: on this Windows checkout `gofmt -l .` lists 78 files, 75 of which this branch never touches, because the working copy has CRLF endings. Rewriting the same file with LF endings and running `gofmt -l` again reports nothing, so the formatting of these comments is fine.

This does not overlap #1152, which only touches `middleware/route_headers.go`.