### PR TITLE
docs: fix punctuation in comments

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -34,12 +34,12 @@ func (c *ChainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // chain builds a http.Handler composed of an inline middleware stack and endpoint
 // handler in the order they are passed.
 func chain(middlewares []func(http.Handler) http.Handler, endpoint http.Handler) http.Handler {
-	// Return ahead of time if there aren't any middlewares for the chain
+	// Return ahead of time if there aren't any middlewares for the chain.
 	if len(middlewares) == 0 {
 		return endpoint
 	}
 
-	// Wrap the end handler with the middleware chain
+	// Wrap the end handler with the middleware chain.
 	h := middlewares[len(middlewares)-1](endpoint)
 	for i := len(middlewares) - 2; i >= 0; i-- {
 		h = middlewares[i](h)

--- a/chi.go
+++ b/chi.go
@@ -39,7 +39,7 @@
 // expression match, for example {number:\\d+}. The regular expression
 // syntax is Go's normal regexp RE2 syntax, except that / will never be
 // matched. An anonymous regexp pattern is allowed, using an empty string
-// before the colon in the placeholder, such as {:\\d+}
+// before the colon in the placeholder, such as {:\\d+}.
 //
 // The special placeholder of asterisk matches the rest of the requested
 // URL. Any trailing characters in the pattern are ignored. This is the only


### PR DESCRIPTION
### Summary
- Add missing trailing period in `chi.go` anonymous regexp pattern doc comment.
- Add missing trailing periods in `chain.go` helper comments.