### PR TITLE
fix(middleware): reject catch-all compress wildcards

### DIFF
--- a/middleware/compress.go
+++ b/middleware/compress.go
@@ -65,6 +65,10 @@ type Compressor struct {
 //
 // The level should be one of the ones defined in the flate package.
 // The types are the content types that are allowed to be compressed.
+//
+// Catch-all wildcards ("*/*", "/*") are rejected: compressing every response
+// wastes CPU on already-compressed types like zip, jpeg or png. Pass explicit
+// types instead, e.g. "text/html" or "application/*".
 func NewCompressor(level int, types ...string) *Compressor {
 	// If types are provided, set those as the allowed types. If none are
 	// provided, use the default list.
@@ -73,9 +77,12 @@ func NewCompressor(level int, types ...string) *Compressor {
 	if len(types) > 0 {
 		for _, t := range types {
 			if strings.Contains(strings.TrimSuffix(t, "/*"), "*") {
-				panic(fmt.Sprintf("middleware/compress: Unsupported content-type wildcard pattern '%s'. Only '/*' supported", t))
+				panic(fmt.Sprintf("middleware/compress: Unsupported content-type wildcard pattern '%s'. Only '<type>/*' supported", t))
 			}
 			if before, ok := strings.CutSuffix(t, "/*"); ok {
+				if before == "" {
+					panic(fmt.Sprintf("middleware/compress: Unsupported content-type wildcard pattern '%s'. Only '<type>/*' supported", t))
+				}
 				allowedWildcards[before] = struct{}{}
 			} else {
 				allowedTypes[t] = struct{}{}

--- a/middleware/compress_test.go
+++ b/middleware/compress_test.go
@@ -153,12 +153,22 @@ func TestCompressorWildcards(t *testing.T) {
 		{
 			name:    "invalid wildcard #1",
 			types:   []string{"audio/*wav"},
-			recover: "middleware/compress: Unsupported content-type wildcard pattern 'audio/*wav'. Only '/*' supported",
+			recover: "middleware/compress: Unsupported content-type wildcard pattern 'audio/*wav'. Only '<type>/*' supported",
 		},
 		{
 			name:    "invalid wildcard #2",
 			types:   []string{"application*/*"},
-			recover: "middleware/compress: Unsupported content-type wildcard pattern 'application*/*'. Only '/*' supported",
+			recover: "middleware/compress: Unsupported content-type wildcard pattern 'application*/*'. Only '<type>/*' supported",
+		},
+		{
+			name:    "catch-all wildcard #1",
+			types:   []string{"*/*"},
+			recover: "middleware/compress: Unsupported content-type wildcard pattern '*/*'. Only '<type>/*' supported",
+		},
+		{
+			name:    "catch-all wildcard #2",
+			types:   []string{"/*"},
+			recover: "middleware/compress: Unsupported content-type wildcard pattern '/*'. Only '<type>/*' supported",
 		},
 		{
 			name:    "valid wildcard",


### PR DESCRIPTION
`NewCompressor(level, "/*")` passed validation but stored an empty wildcard key that never matched any Content-Type, silently compressing nothing.

Instead of turning it into a compress-everything catch-all, reject both `"/*"` and `"*/*"` at construction: compressing every response wastes CPU on already-compressed types (zip, jpeg, png), which is why the middleware keeps a curated default list. Users should pass explicit content types.

Fixes https://github.com/go-chi/chi/issues/868.

Supersedes https://github.com/go-chi/chi/pull/1121.