### PR TITLE
Add Clone method to Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -95,6 +95,22 @@ func (x *Context) Reset() {
 	x.parentCtx = nil
 }
 
+// Clone a routing context so that it may be used outside of the request/response lifecycle.
+func (c *Context) Clone() *Context {
+	clone := *c
+
+	clone.URLParams.Keys = append([]string(nil), c.URLParams.Keys...)
+	clone.URLParams.Values = append([]string(nil), c.URLParams.Values...)
+
+	clone.routeParams.Keys = append([]string(nil), c.routeParams.Keys...)
+	clone.routeParams.Values = append([]string(nil), c.routeParams.Values...)
+
+	clone.RoutePatterns = append([]string(nil), c.RoutePatterns...)
+	clone.methodsAllowed = append([]methodTyp(nil), c.methodsAllowed...)
+
+	return &clone
+}
+
 // URLParam returns the corresponding URL parameter value from the request
 // routing context.
 func (x *Context) URLParam(key string) string {

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package chi
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 )
 
@@ -99,14 +100,14 @@ func (x *Context) Reset() {
 func (c *Context) Clone() *Context {
 	clone := *c
 
-	clone.URLParams.Keys = append([]string(nil), c.URLParams.Keys...)
-	clone.URLParams.Values = append([]string(nil), c.URLParams.Values...)
+	clone.URLParams.Keys = slices.Clone(c.URLParams.Keys)
+	clone.URLParams.Values = slices.Clone(c.URLParams.Values)
 
-	clone.routeParams.Keys = append([]string(nil), c.routeParams.Keys...)
-	clone.routeParams.Values = append([]string(nil), c.routeParams.Values...)
+	clone.routeParams.Keys = slices.Clone(c.routeParams.Keys)
+	clone.routeParams.Values = slices.Clone(c.routeParams.Values)
 
-	clone.RoutePatterns = append([]string(nil), c.RoutePatterns...)
-	clone.methodsAllowed = append([]methodTyp(nil), c.methodsAllowed...)
+	clone.RoutePatterns = slices.Clone(c.RoutePatterns)
+	clone.methodsAllowed = slices.Clone(c.methodsAllowed)
 
 	return &clone
 }

--- a/context.go
+++ b/context.go
@@ -43,6 +43,8 @@ var (
 // Context is the default routing context set on the root node of a
 // request context to track route patterns, URL parameters and
 // an optional routing path.
+//
+// NOTE: New reference fields (slices, maps, pointers) must be deep-copied in Clone.
 type Context struct {
 	Routes Routes
 
@@ -96,18 +98,26 @@ func (x *Context) Reset() {
 	x.parentCtx = nil
 }
 
-// Clone a routing context so that it may be used outside of the request/response lifecycle.
-func (c *Context) Clone() *Context {
-	clone := *c
+// Clone a routing context so that it may be used outside of the request/response
+// lifecycle, e.g. in a goroutine that outlives the request handler.
+//
+// Clone must be called before the request handler returns; after that, the
+// original context is reset and put back into the pool for reuse by another
+// request, racing with the copy.
+func (x *Context) Clone() *Context {
+	clone := *x
 
-	clone.URLParams.Keys = slices.Clone(c.URLParams.Keys)
-	clone.URLParams.Values = slices.Clone(c.URLParams.Values)
+	// Detach from the request's context, which is canceled once the request finishes.
+	clone.parentCtx = nil
 
-	clone.routeParams.Keys = slices.Clone(c.routeParams.Keys)
-	clone.routeParams.Values = slices.Clone(c.routeParams.Values)
+	clone.URLParams.Keys = slices.Clone(x.URLParams.Keys)
+	clone.URLParams.Values = slices.Clone(x.URLParams.Values)
 
-	clone.RoutePatterns = slices.Clone(c.RoutePatterns)
-	clone.methodsAllowed = slices.Clone(c.methodsAllowed)
+	clone.routeParams.Keys = slices.Clone(x.routeParams.Keys)
+	clone.routeParams.Values = slices.Clone(x.routeParams.Values)
+
+	clone.RoutePatterns = slices.Clone(x.RoutePatterns)
+	clone.methodsAllowed = slices.Clone(x.methodsAllowed)
 
 	return &clone
 }

--- a/context_test.go
+++ b/context_test.go
@@ -102,3 +102,47 @@ func TestReplaceWildcardsConsecutive(t *testing.T) {
 		t.Fatalf("unexpected trailing wildcard behavior: %s", p)
 	}
 }
+
+func TestContext_Clone(t *testing.T) {
+	orig := &Context{
+		RoutePatterns:  []string{"/v1", "/resources/{id}"},
+		methodsAllowed: []methodTyp{mHEAD, mGET},
+		URLParams: RouteParams{
+			Keys:   []string{"foo"},
+			Values: []string{"bar"},
+		},
+		routeParams: RouteParams{
+			Keys:   []string{"id"},
+			Values: []string{"123"},
+		},
+	}
+
+	clone := orig.Clone()
+	orig.Reset()
+
+	orig.URLParams.Keys = append(orig.URLParams.Keys, "bar")
+	orig.URLParams.Values = append(orig.URLParams.Values, "baz")
+	orig.routeParams.Keys = append(orig.routeParams.Keys, "name")
+	orig.routeParams.Values = append(orig.routeParams.Values, "foxmulder")
+	orig.RoutePatterns = append(orig.RoutePatterns, "/mutated")
+	orig.methodsAllowed = append(orig.methodsAllowed, mPOST)
+
+	if got := clone.URLParams.Keys[0]; got != "foo" {
+		t.Fatalf("clone URLParams.Keys was corrupted, want %q got %q", "foo", got)
+	}
+	if got := clone.URLParams.Values[0]; got != "bar" {
+		t.Fatalf("clone URLParams.Values was corrupted, want %q got %q", "bar", got)
+	}
+	if got := clone.routeParams.Keys[0]; got != "id" {
+		t.Fatalf("clone routeParams.Keys was corrupted, want %q got %q", "id", got)
+	}
+	if got := clone.routeParams.Values[0]; got != "123" {
+		t.Fatalf("clone routeParams.Values was corrupted, want %q got %q", "123", got)
+	}
+	if got := clone.RoutePatterns[0]; got != "/v1" {
+		t.Fatalf("clone RoutePatterns[0] was corrupted, want %q got %q", "/v1", got)
+	}
+	if got := clone.methodsAllowed[0]; got != mHEAD {
+		t.Fatalf("clone methodsAllowed[0] was corrupted, want %d got %d", mHEAD, got)
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,9 @@
 package chi
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // TestRoutePattern tests correct in-the-middle wildcard removals.
 // If user organizes a router like this:
@@ -105,6 +108,7 @@ func TestReplaceWildcardsConsecutive(t *testing.T) {
 
 func TestContext_Clone(t *testing.T) {
 	orig := &Context{
+		parentCtx:      context.Background(),
 		RoutePatterns:  []string{"/v1", "/resources/{id}"},
 		methodsAllowed: []methodTyp{mHEAD, mGET},
 		URLParams: RouteParams{
@@ -144,5 +148,8 @@ func TestContext_Clone(t *testing.T) {
 	}
 	if got := clone.methodsAllowed[0]; got != mHEAD {
 		t.Fatalf("clone methodsAllowed[0] was corrupted, want %d got %d", mHEAD, got)
+	}
+	if clone.parentCtx != nil {
+		t.Fatalf("clone parentCtx should be detached, got %v", clone.parentCtx)
 	}
 }


### PR DESCRIPTION
This includes #1033 by @BlakeWilliams as-is (rebased onto current master, commit authorship preserved), plus a follow-up commit applying the review feedback:

- `Clone()` detaches `parentCtx`, so the clone doesn't pin the finished request's context.
- Doc comment spells out that `Clone()` must be called before the handler returns.
- `Context` struct notes that new reference fields must be deep-copied in `Clone()`.

Credit to @BlakeWilliams for the implementation and the design discussion in #1028.

Closes #1028
Closes #1033
