### PR TITLE
middleware: ContentCharset should skip requests without a body

### DIFF
--- a/middleware/content_charset.go
+++ b/middleware/content_charset.go
@@ -15,6 +15,11 @@ func ContentCharset(charsets ...string) func(next http.Handler) http.Handler {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ContentLength == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			if !contentEncoding(r.Header.Get("Content-Type"), charsets...) {
 				w.WriteHeader(http.StatusUnsupportedMediaType)
 				return

--- a/middleware/content_charset.go
+++ b/middleware/content_charset.go
@@ -8,6 +8,7 @@ import (
 
 // ContentCharset generates a handler that writes a 415 Unsupported Media Type response if none of the charsets match.
 // An empty charset will allow requests with no Content-Type header or no specified charset.
+// Requests without a body (ContentLength == 0) are always allowed.
 func ContentCharset(charsets ...string) func(next http.Handler) http.Handler {
 	for i, c := range charsets {
 		charsets[i] = strings.ToLower(c)

--- a/middleware/content_charset_test.go
+++ b/middleware/content_charset_test.go
@@ -15,55 +15,71 @@ func TestContentCharset(t *testing.T) {
 		name                string
 		inputValue          string
 		inputContentCharset []string
+		contentLength       int64
 		want                int
 	}{
 		{
 			"should accept requests with a matching charset",
 			"application/json; charset=UTF-8",
 			[]string{"UTF-8"},
+			100,
 			http.StatusOK,
 		},
 		{
 			"should be case-insensitive",
 			"application/json; charset=utf-8",
 			[]string{"UTF-8"},
+			100,
 			http.StatusOK,
 		},
 		{
 			"should accept requests with a matching charset with extra values",
 			"application/json; foo=bar; charset=UTF-8; spam=eggs",
 			[]string{"UTF-8"},
+			100,
 			http.StatusOK,
 		},
 		{
 			"should accept requests with a matching charset when multiple charsets are supported",
 			"text/xml; charset=UTF-8",
 			[]string{"UTF-8", "Latin-1"},
+			100,
 			http.StatusOK,
 		},
 		{
 			"should accept requests with no charset if empty charset headers are allowed",
 			"text/xml",
 			[]string{"UTF-8", ""},
+			100,
 			http.StatusOK,
 		},
 		{
 			"should not accept requests with no charset if empty charset headers are not allowed",
 			"text/xml",
 			[]string{"UTF-8"},
+			100,
 			http.StatusUnsupportedMediaType,
 		},
 		{
 			"should not accept requests with a mismatching charset",
 			"text/plain; charset=Latin-1",
 			[]string{"UTF-8"},
+			100,
 			http.StatusUnsupportedMediaType,
 		},
 		{
 			"should not accept requests with a mismatching charset even if empty charsets are allowed",
 			"text/plain; charset=Latin-1",
 			[]string{"UTF-8", ""},
+			100,
 			http.StatusUnsupportedMediaType,
+		},
+		{
+			"should skip charset validation if ContentLength is 0",
+			"text/plain; charset=Latin-1",
+			[]string{"UTF-8"},
+			0,
+			http.StatusOK,
 		},
 	}
 

--- a/middleware/content_charset_test.go
+++ b/middleware/content_charset_test.go
@@ -1,8 +1,10 @@
 package middleware
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -15,70 +17,77 @@ func TestContentCharset(t *testing.T) {
 		name                string
 		inputValue          string
 		inputContentCharset []string
-		contentLength       int64
+		body                string
 		want                int
 	}{
 		{
 			"should accept requests with a matching charset",
 			"application/json; charset=UTF-8",
 			[]string{"UTF-8"},
-			100,
+			"foobar",
 			http.StatusOK,
 		},
 		{
 			"should be case-insensitive",
 			"application/json; charset=utf-8",
 			[]string{"UTF-8"},
-			100,
+			"foobar",
 			http.StatusOK,
 		},
 		{
 			"should accept requests with a matching charset with extra values",
 			"application/json; foo=bar; charset=UTF-8; spam=eggs",
 			[]string{"UTF-8"},
-			100,
+			"foobar",
 			http.StatusOK,
 		},
 		{
 			"should accept requests with a matching charset when multiple charsets are supported",
 			"text/xml; charset=UTF-8",
 			[]string{"UTF-8", "Latin-1"},
-			100,
+			"foobar",
 			http.StatusOK,
 		},
 		{
 			"should accept requests with no charset if empty charset headers are allowed",
 			"text/xml",
 			[]string{"UTF-8", ""},
-			100,
+			"foobar",
 			http.StatusOK,
 		},
 		{
 			"should not accept requests with no charset if empty charset headers are not allowed",
 			"text/xml",
 			[]string{"UTF-8"},
-			100,
+			"foobar",
 			http.StatusUnsupportedMediaType,
 		},
 		{
 			"should not accept requests with a mismatching charset",
 			"text/plain; charset=Latin-1",
 			[]string{"UTF-8"},
-			100,
+			"foobar",
 			http.StatusUnsupportedMediaType,
 		},
 		{
 			"should not accept requests with a mismatching charset even if empty charsets are allowed",
 			"text/plain; charset=Latin-1",
 			[]string{"UTF-8", ""},
-			100,
+			"foobar",
 			http.StatusUnsupportedMediaType,
 		},
 		{
-			"should skip charset validation if ContentLength is 0",
+			"should skip validation for requests without a body",
 			"text/plain; charset=Latin-1",
 			[]string{"UTF-8"},
-			0,
+			"",
+			http.StatusOK,
+		},
+		{
+			"should skip validation for requests without a body and no Content-Type header",
+			"",
+			[]string{"UTF-8"},
+			"",
 			http.StatusOK,
 		},
 	}
@@ -92,10 +101,17 @@ func TestContentCharset(t *testing.T) {
 
 			var r = chi.NewRouter()
 			r.Use(ContentCharset(tt.inputContentCharset...))
-			r.Get("/", func(w http.ResponseWriter, r *http.Request) {})
+			r.Post("/", func(w http.ResponseWriter, r *http.Request) {})
 
-			var req, _ = http.NewRequest("GET", "/", nil)
-			req.Header.Set("Content-Type", tt.inputValue)
+			var body io.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			}
+
+			var req, _ = http.NewRequest("POST", "/", body)
+			if tt.inputValue != "" {
+				req.Header.Set("Content-Type", tt.inputValue)
+			}
 
 			r.ServeHTTP(recorder, req)
 			var res = recorder.Result()


### PR DESCRIPTION
Cherry-picked from #942 by @noazaj (fixes #746), plus a fix to its tests.

`ContentCharset` used to 415 any request without a body — e.g. every GET — unless it carried a matching charset header. Now it passes bodyless requests (`ContentLength == 0`) through, consistent with `AllowContentType` and `AllowContentEncoding`. Chunked requests (`ContentLength == -1`) are still validated.

The original PR's tests didn't pass: the `contentLength` table field was never applied to the request, so every case ran with `ContentLength == 0` and the three 415 cases failed. Tests now drive `ContentLength` from a real request body, and cover the bodyless request with no `Content-Type` header — the exact scenario from #746.