### PR TITLE
Fix exponential-time DoS when route insertion panics

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -146,6 +146,11 @@ func (s endpoints) Value(method methodTyp) *endpoint {
 }
 
 func (n *node) InsertRoute(method methodTyp, pattern string, handler http.Handler) *node {
+	// Validate the pattern up-front so a malformed route (duplicate or empty
+	// param key, misplaced wildcard, missing '}') panics BEFORE the tree is
+	// mutated.
+	patParamKeys(pattern)
+
 	var parent *node
 	search := pattern
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 )
 
 func TestTree(t *testing.T) {
@@ -711,5 +713,47 @@ func TestWalkMiddlewaresAcrossGroupAndRoute(t *testing.T) {
 		if gotMws := got[route]; !slices.Equal(gotMws, wantMws) {
 			t.Fatalf("%s: expected middlewares %v, got %v", route, wantMws, gotMws)
 		}
+	}
+}
+
+// TestInsertRoutePanicLeavesTreeClean guards against a regression where a
+// malformed route pattern panics partway through insertion and leaves a
+// partially-built node chain in the tree. Such a poisoned chain made
+// subsequent route lookups backtrack exponentially (algorithmic DoS): a
+// 2-byte request like "/{" could take ~17s on some malformed patterns.
+func TestInsertRoutePanicLeavesTreeClean(t *testing.T) {
+	// Malformed pattern: duplicate empty param keys. InsertRoute must panic
+	// before mutating the tree (validated up front in InsertRoute).
+	malformed := "/{" + "}{}{}{}{}{}{}{}{}{}{\r\r\r\r\r\r\r}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}" + "}"
+	mux := NewRouter()
+
+	mux.Get("/ok", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatalf("expected InsertRoute to panic on malformed pattern %q", malformed)
+			}
+		}()
+		mux.Get(malformed, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	}()
+
+	start := time.Now()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/{", nil)
+	mux.ServeHTTP(rr, req)
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("routing %q after a panicking insertion is pathologically slow: %v", "/{", elapsed)
+	}
+
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "http://localhost/ok", nil)
+	mux.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("valid route no longer matches after panicking insertion: got code %d", rr2.Code)
 	}
 }


### PR DESCRIPTION
InsertRoute builds a route into the radix tree incrementally, appending each node as it descends. Validation that rejects a malformed pattern — duplicate or empty param keys — only runs afterwards, in setEndpoint → patParamKeys. When that panics, the partially-built node chain is left in the tree, and a subsequent request descending into it makes findRoute backtrack exponentially: for a pattern ending in k empty param segments, routing a trivial path like "/{" grows ~4-6x per +2 segments (k=20 -> ~17s). That is an algorithmic-complexity DoS.