### PR TITLE
Bump minimum Go to 1.24, use b.Loop()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x, 1.25.x, 1.26.x]
+        go-version: [1.24.x, 1.25.x, 1.26.x, 1.27.x]
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-chi/chi/v5
 
 // Chi supports the four most recent major versions of Go.
 // See https://github.com/go-chi/chi/issues/963.
-go 1.23
+go 1.24

--- a/middleware/client_ip_bench_test.go
+++ b/middleware/client_ip_bench_test.go
@@ -25,7 +25,7 @@ func BenchmarkWalkXFF(b *testing.B) {
 
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				walkXFF(headers, func(entry string) bool {
 					return false // walk to the leftmost entry
 				})
@@ -48,7 +48,7 @@ func BenchmarkWalkXFF_RightmostStop(b *testing.B) {
 
 		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				walkXFF(headers, func(entry string) bool {
 					return true // stop at the rightmost entry
 				})

--- a/middleware/throttle_test.go
+++ b/middleware/throttle_test.go
@@ -321,9 +321,8 @@ func BenchmarkThrottle(b *testing.B) {
 
 	req := httptest.NewRequest("GET", "/", nil)
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, req)
 	}

--- a/mux_test.go
+++ b/mux_test.go
@@ -2153,9 +2153,7 @@ func BenchmarkMux(b *testing.B) {
 			r, _ := http.NewRequest("GET", path, nil)
 
 			b.ReportAllocs()
-			b.ResetTimer()
-
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				mx.ServeHTTP(w, r)
 			}
 		})

--- a/tree_test.go
+++ b/tree_test.go
@@ -503,9 +503,7 @@ func BenchmarkTreeGet(b *testing.B) {
 	mctx := NewRouteContext()
 
 	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		mctx.Reset()
 		tr.FindRoute(mctx, mGET, "/ping/123/456")
 	}


### PR DESCRIPTION
Go 1.27 is out now so we can bump our minimum Go to 1.24