### PR TITLE
Remove superfluous import aliases

### DIFF
--- a/middleware/basic_auth_test.go
+++ b/middleware/basic_auth_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	chi "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5"
 )
 
 var testAuthCreds = map[string]string{

--- a/middleware/clean_path_test.go
+++ b/middleware/clean_path_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	chi "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5"
 )
 
 func TestCleanPath(t *testing.T) {

--- a/middleware/heartbeat_test.go
+++ b/middleware/heartbeat_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	chi "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5"
 )
 
 func TestHeartbeat(t *testing.T) {

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	chi "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5"
 )
 
 var testdataDir string

--- a/middleware/path_rewrite_test.go
+++ b/middleware/path_rewrite_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	chi "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5"
 )
 
 func TestPathRewrite(t *testing.T) {

--- a/middleware/value_test.go
+++ b/middleware/value_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	chi "github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5"
 )
 
 func TestWithValue(t *testing.T) {


### PR DESCRIPTION
The package name is already "chi", the version doesn't affect this. Unaliased is by far the most common style in the codebase:
```
 $ git grep -Ph '^\t(\w+ )?"github.com/go-chi/chi/v5"' | sort | uniq -c
      6 	chi "github.com/go-chi/chi/v5"
     34 	"github.com/go-chi/chi/v5"
```